### PR TITLE
Reconnect backoff, honor connection timeout, drop deprecated utcnow

### DIFF
--- a/tests/test_blelogic.py
+++ b/tests/test_blelogic.py
@@ -4,6 +4,7 @@ import logging
 import unittest
 import asyncio
 import sys
+from unittest.mock import patch
 from bleak import BleakGATTCharacteristic
 from bleak.exc import BleakCharacteristicNotFoundError
 from vvm_to_signalk.ble_connection import BleDeviceConnection, BleConnectionConfig
@@ -117,6 +118,67 @@ def test_retrieve_device_info_handles_missing_characteristics():
     # Must not raise even though every characteristic read returns None
     asyncio.get_event_loop().run_until_complete(
         conn._retrieve_device_info(MissingCharsClient()))
+
+
+class Test_ConnectionLifecycle(unittest.IsolatedAsyncioTestCase):
+    """Tests for the connect / reconnect lifecycle"""
+
+    async def test_connection_timeout_passed_to_bleak_client(self):
+        """The configured connection timeout must be handed to BleakClient."""
+        config = BleConnectionConfig()
+        config.device_name = "UnitTestRunner"
+        config.connection_timeout = 17.0
+        decoder = BleDeviceConnection(config, {})
+
+        captured = {}
+
+        class FakeClient:
+            """Records constructor args then bails out of the context manager"""
+            def __init__(self, device, disconnected_callback=None, timeout=None, **kwargs):
+                captured["timeout"] = timeout
+
+            async def __aenter__(self):
+                raise RuntimeError("stop after construction")
+
+            async def __aexit__(self, *args):
+                return False
+
+        with patch("vvm_to_signalk.ble_connection.BleakClient", FakeClient):
+            await decoder._device_init_and_loop("fake-device")
+
+        assert captured["timeout"] == 17.0
+
+    async def test_run_backs_off_after_failed_connection(self):
+        """After a failed connection cycle the loop should wait retry_interval
+        before scanning again, instead of busy-looping."""
+        config = BleConnectionConfig()
+        config.device_name = "UnitTestRunner"
+        config.retry_interval = 7
+        decoder = BleDeviceConnection(config, {})
+
+        sleeps = []
+
+        async def fake_sleep(seconds):
+            sleeps.append(seconds)
+
+        cycles = {"n": 0}
+
+        async def fake_scan():
+            return "fake-device"
+
+        async def fake_init(_device):
+            cycles["n"] += 1
+            if cycles["n"] >= 2:
+                await decoder.close()
+            return False
+
+        decoder._scan_for_device = fake_scan
+        decoder._device_init_and_loop = fake_init
+
+        with patch("vvm_to_signalk.ble_connection.asyncio.sleep", fake_sleep):
+            await decoder.run(task_group=None)
+
+        assert 7 in sleeps
 
 
 if __name__ == "__main__":

--- a/tests/test_healthcheck.py
+++ b/tests/test_healthcheck.py
@@ -3,7 +3,8 @@
 import os
 import tempfile
 import unittest
-from datetime import datetime, timedelta
+import warnings
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
 
 from vvm_to_signalk.healthcheck import format_heartbeat, is_healthy, main
@@ -70,7 +71,7 @@ class TestHealthcheckMain(unittest.TestCase):
     def test_main_exits_zero_for_fresh_ok_file(self):
         """main() returns 0 when the heartbeat file is fresh and OK"""
         with tempfile.NamedTemporaryFile("w", suffix=".hc", delete=False) as f:
-            f.write(format_heartbeat(signalk_ok=True, now=datetime.utcnow()))
+            f.write(format_heartbeat(signalk_ok=True, now=datetime.now(timezone.utc)))
             path = f.name
         try:
             with patch.dict(os.environ, {"APP_HEALTHCHECK_FILE": path}):
@@ -81,7 +82,7 @@ class TestHealthcheckMain(unittest.TestCase):
     def test_main_exits_one_for_bad_file(self):
         """main() returns 1 when the heartbeat reports a fault"""
         with tempfile.NamedTemporaryFile("w", suffix=".hc", delete=False) as f:
-            f.write(format_heartbeat(signalk_ok=False, now=datetime.utcnow()))
+            f.write(format_heartbeat(signalk_ok=False, now=datetime.now(timezone.utc)))
             path = f.name
         try:
             with patch.dict(os.environ, {"APP_HEALTHCHECK_FILE": path}):
@@ -93,6 +94,42 @@ class TestHealthcheckMain(unittest.TestCase):
         """main() returns 1 when the heartbeat file does not exist"""
         with patch.dict(os.environ, {"APP_HEALTHCHECK_FILE": "/nonexistent/hc_xyz"}):
             self.assertEqual(main(), 1)
+
+    def test_main_does_not_use_deprecated_utcnow(self):
+        """main() must not rely on the deprecated datetime.utcnow()."""
+        with tempfile.NamedTemporaryFile("w", suffix=".hc", delete=False) as f:
+            f.write(format_heartbeat(signalk_ok=True, now=datetime.now(timezone.utc)))
+            path = f.name
+        try:
+            with patch.dict(os.environ, {"APP_HEALTHCHECK_FILE": path}):
+                with warnings.catch_warnings(record=True) as caught:
+                    warnings.simplefilter("always")
+                    main()
+            deprecations = [
+                w for w in caught
+                if issubclass(w.category, DeprecationWarning) and "utcnow" in str(w.message)
+            ]
+            self.assertEqual(deprecations, [])
+        finally:
+            os.unlink(path)
+
+
+class TestTimezoneAwareHeartbeat(unittest.TestCase):
+    """The healthcheck must work with timezone-aware timestamps"""
+
+    def test_aware_ok_heartbeat_round_trips_to_healthy(self):
+        """A timezone-aware OK heartbeat reads as healthy"""
+        now = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+        content = format_heartbeat(signalk_ok=True, now=now)
+        self.assertTrue(is_healthy(content, now=now, max_age_seconds=60))
+
+    def test_naive_file_with_aware_now_does_not_crash(self):
+        """A legacy naive heartbeat file evaluated against an aware now (the
+        upgrade-transition case) must not raise and must read as healthy."""
+        written = datetime(2026, 6, 19, 12, 0, 0)  # naive, legacy format
+        now = datetime(2026, 6, 19, 12, 0, 0, tzinfo=timezone.utc)
+        content = f"OK {written.isoformat()}\n"
+        self.assertTrue(is_healthy(content, now=now, max_age_seconds=60))
 
 
 if __name__ == "__main__":

--- a/vvm_to_signalk/ble_connection.py
+++ b/vvm_to_signalk/ble_connection.py
@@ -91,7 +91,14 @@ class BleDeviceConnection:
             logger.info("Starting device data loop")
             
             # configure the device and loop until abort or disconnect
-            await self._device_init_and_loop(found_device)
+            connected = await self._device_init_and_loop(found_device)
+
+            # If we never managed to connect, back off before retrying so a
+            # persistent device-side error doesn't busy-loop the scan/connect cycle.
+            if not connected and not self.__abort:
+                logger.info("Connection attempt failed; backing off for %s seconds before retrying",
+                            self.retry_interval)
+                await asyncio.sleep(self.retry_interval)
 
             logger.info("Returning to device scan loop")
 
@@ -106,15 +113,23 @@ class BleDeviceConnection:
             logger.info(message)
 
 
-    async def _device_init_and_loop(self, device):
-        """Initalize BLE device and loop receiving data"""
+    async def _device_init_and_loop(self, device) -> bool:
+        """Initalize BLE device and loop receiving data.
+
+        Returns True if a connection was established (and later disconnected),
+        or False if the attempt failed before connecting. The caller uses this
+        to decide whether to back off before retrying.
+        """
         monitor_task = None
+        connected = False
         try:
             async with BleakClient(device,
-                                    disconnected_callback=self.device_disconnected
+                                    disconnected_callback=self.device_disconnected,
+                                    timeout=self.__config.connection_timeout
                                     ) as client:
-                
+
                 self._set_health(True, "Connected to device")
+                connected = True
 
                 logger.info("Retrieving device identification metadata...")
                 await self._retrieve_device_info(client)
@@ -145,6 +160,8 @@ class BleDeviceConnection:
             if monitor_task:
                 monitor_task.cancel()
             self.__cancel_signal = asyncio.Future()
+
+        return connected
 
     async def _monitor_streaming(self):
         """Monitors the streaming data and cancels the connection if it times out"""

--- a/vvm_to_signalk/healthcheck.py
+++ b/vvm_to_signalk/healthcheck.py
@@ -10,7 +10,7 @@ stays healthy.
 
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 DEFAULT_HEALTHCHECK_FILE = "/tmp/healthcheck"
 DEFAULT_MAX_AGE_SECONDS = 60
@@ -31,8 +31,10 @@ def format_heartbeat(signalk_ok: bool, now: datetime) -> str:
 def is_healthy(content: str, now: datetime, max_age_seconds: int = DEFAULT_MAX_AGE_SECONDS) -> bool:
     """Return True when the heartbeat content reports OK and is fresh.
 
-    ``content`` is the raw heartbeat file content. ``now`` is the current time
-    (naive UTC, matching how the heartbeat timestamp is written).
+    ``content`` is the raw heartbeat file content. ``now`` is the current time;
+    naive values are treated as UTC. Heartbeats written by older versions used a
+    naive UTC timestamp, so both sides are normalised to timezone-aware UTC
+    before comparison to stay compatible across an upgrade.
     """
     line = content.strip()
     if not line:
@@ -51,8 +53,18 @@ def is_healthy(content: str, now: datetime, max_age_seconds: int = DEFAULT_MAX_A
     except ValueError:
         return False
 
+    now = _as_utc(now)
+    written = _as_utc(written)
+
     age = (now - written).total_seconds()
     return 0 <= age <= max_age_seconds
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Treat a naive datetime as UTC; leave aware datetimes unchanged."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value
 
 
 def main() -> int:
@@ -64,7 +76,7 @@ def main() -> int:
     except OSError:
         return 1
 
-    return 0 if is_healthy(content, now=datetime.utcnow()) else 1
+    return 0 if is_healthy(content, now=datetime.now(timezone.utc)) else 1
 
 
 if __name__ == "__main__":

--- a/vvm_to_signalk/vvm_monitor.py
+++ b/vvm_to_signalk/vvm_monitor.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import os
 import signal
-from datetime import datetime
+from datetime import datetime, timezone
 from logging.handlers import RotatingFileHandler
 
 import yaml
@@ -222,7 +222,7 @@ class VesselViewMobileDataRecorder:
         """Write the healthcheck status to a file"""
         while True:
             with open("/tmp/healthcheck", "w", encoding="utf-8") as f:
-                f.write(format_heartbeat(self.__health["signalk"], datetime.utcnow()))
+                f.write(format_heartbeat(self.__health["signalk"], datetime.now(timezone.utc)))
             await asyncio.sleep(15)
 
 class VVMConfig:


### PR DESCRIPTION
## Summary

Follow-up to #38, addressing three more items from the `main` reliability review. Independent of #38 (touches different methods), so it can merge in either order.

### #3 — Reconnect loop had no backoff (and `retry_interval` was dead config)
`run()` re-entered the scan/connect cycle immediately after a failed connection, and `retry-interval-seconds` was parsed into config but never used. On a persistent device-side error this could spin the scan/connect cycle.

`_device_init_and_loop` now returns whether it actually connected, and `run()` sleeps `retry_interval` before retrying a **failed** attempt. A normal connect-then-disconnect still reconnects immediately (no added latency for the common case).

### #4 — `connection-timeout-seconds` was never applied
The value was parsed into config but never passed to `BleakClient`, which silently used its own default. It's now passed through.

### #5 — `datetime.utcnow()` is deprecated
The image pins Python 3.13, where `utcnow()` emits a `DeprecationWarning`. The heartbeat writer (`write_healthcheck`) and checker (`healthcheck.main`) now use `datetime.now(timezone.utc)`. `is_healthy` normalises both naive and aware timestamps to UTC, so it stays compatible with heartbeat files written by an older version across an upgrade.

## Testing
- New tests, written test-first: connection-timeout is passed to `BleakClient`; `run()` backs off after a failed cycle; `main()` emits no `utcnow` deprecation; timezone-aware and legacy-naive heartbeats both evaluate correctly.
- Full suite: **56 passed**, no more `utcnow` deprecation warnings.
- `pylint` on changed modules: 9.93/10, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)