### PR TITLE
Publish versioned (semver) Docker image tags

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,19 +1,28 @@
 name: Publish Docker Image
+
+# Tagging scheme (see README "Image tags"):
+#   - push a semver git tag vX.Y.Z  -> X.Y.Z, X.Y, X, and latest
+#   - push to main                  -> edge
+#   - push to dev                   -> dev
 on:
   push:
     branches:
       - main
       - dev
-  label:
-    types:
-      - created
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
-    - name: Set up Docekr Buildx
+    - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
     - name: Login to Docker Hub
       uses: docker/login-action@v3
@@ -26,10 +35,20 @@ jobs:
       uses: docker/metadata-action@v5
       with:
         images: rgregg/vvm_monitor
+        # latest is applied automatically for semver tag builds (latest=auto).
+        flavor: |
+          latest=auto
+        tags: |
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=semver,pattern={{major}}
+          type=edge,branch=main
+          type=ref,event=branch,enable=${{ github.ref_name != 'main' }}
     - name: Build and push
       uses: docker/build-push-action@v6
       with:
+        context: .
         platforms: linux/amd64,linux/arm64,linux/arm/v7
-        push: ${{ github.event_name != 'pull_request' }}
+        push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}

--- a/README.md
+++ b/README.md
@@ -53,6 +53,27 @@ docker run  \
   vvm_monitor
 ```
 
+### Image tags
+
+Images are published to Docker Hub as [`rgregg/vvm_monitor`](https://hub.docker.com/r/rgregg/vvm_monitor) with the following tags:
+
+| Tag | Points to | Use when you want… |
+| --- | --- | --- |
+| `latest` | the newest release | the latest stable version |
+| `1.2.3` | one exact release | to pin an exact version |
+| `1.2` | newest patch of 1.2 | bug-fix updates, no new features |
+| `1` | newest 1.x release | feature updates, no breaking changes |
+| `edge` | the tip of `main` | the bleeding edge (may be unstable) |
+| `pr-<n>` | an open pull request | trying a change before it merges |
+
+For production, pin to a major or major-minor tag (e.g. `rgregg/vvm_monitor:1` or `:1.2`) so you get fixes without surprises. The image also records its version in the standard `org.opencontainers.image.version` label (`docker inspect`).
+
+Releases are cut by pushing a semver git tag (or publishing a GitHub Release):
+
+```bash
+git tag v1.2.3 && git push origin v1.2.3
+```
+
 ### Running as a non-root user
 
 The container runs as an unprivileged user (`vvm`, UID/GID `1000`) rather than root.


### PR DESCRIPTION
## Summary

Lets users pin a particular version / major-minor version of the Docker image. Tags are now driven from semver git tags via `docker/metadata-action`.

### Tagging scheme
| Event | Tags produced |
| --- | --- |
| push git tag `vX.Y.Z` | `X.Y.Z`, `X.Y`, `X`, `latest` |
| push to `main` | `edge` |
| push to `dev` | `dev` |
| open PR (existing workflow) | `pr-<n>` |

So `:latest` now tracks the **newest release** (not a branch build), `:1`/`:1.2` give safe rolling updates, and `:edge` is the bleeding edge. The standard OCI `org.opencontainers.image.version`/`.revision`/`.source` labels are stamped into the image too (visible via `docker inspect`).

### Also in this change
- Drops the stray `label: created` trigger (it would publish an image whenever a repo label was created).
- Fixes the "Set up Docekr Buildx" step-name typo.
- Adds `workflow_dispatch` for manual re-publish.
- Documents the tag scheme and release process in the README.

## Rollout / how to verify
The publish workflow only runs on `main`/`dev`/tag pushes, so it won't run on this PR. After merge:
1. The push to `main` publishes `:edge`.
2. Cutting the first release — `git tag v1.0.0 && git push origin v1.0.0` (per our decision to start at 1.0.0) — publishes `1.0.0`, `1.0`, `1`, and `latest`.

> Note: the tag build runs the workflow **as it exists at the tagged commit**, so `v1.0.0` must be tagged on a `main` commit that already includes this change (i.e. after this PR merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)