### PR TITLE
Only subscribe to notify characteristics, not indicate (fixes no-engine-data)

### DIFF
--- a/tests/test_blelogic.py
+++ b/tests/test_blelogic.py
@@ -120,6 +120,46 @@ def test_retrieve_device_info_handles_missing_characteristics():
         conn._retrieve_device_info(MissingCharsClient()))
 
 
+def test_setup_data_notifications_skips_indicate_only():
+    """Regression: the VVM drops the BLE link (ATT 0x0e) if we subscribe to its
+    indicate-type control characteristics (0x301/0x302/0x401, 0x2a05). Only
+    'notify' characteristics carry streaming data, so indicate-only ones must
+    not be subscribed."""
+    asyncio.set_event_loop(asyncio.new_event_loop())
+    conn = BleDeviceConnection(BleConnectionConfig({"name": "x"}), {})
+
+    class PropChar:
+        """Characteristic stand-in carrying a uuid and GATT properties."""
+        def __init__(self, uuid, properties):
+            self.uuid = uuid
+            self.properties = properties
+
+    class FakeService:
+        """Service exposing a fixed list of characteristics."""
+        def __init__(self, characteristics):
+            self.characteristics = characteristics
+
+    notify_char = PropChar("00000102-0000-1000-8000-ec55f9f5b963", ["read", "notify"])
+    indicate_char = PropChar("00000401-0000-1000-8000-ec55f9f5b963", ["read", "indicate"])
+    service_changed = PropChar("00002a05-0000-1000-8000-00805f9b34fb", ["indicate"])
+
+    subscribed = []
+
+    class FakeClient:
+        """Captures which characteristic UUIDs get a start_notify."""
+        services = [FakeService([notify_char, indicate_char, service_changed])]
+
+        async def start_notify(self, uuid, _handler):
+            subscribed.append(uuid)
+
+    asyncio.get_event_loop().run_until_complete(
+        conn._setup_data_notifications(FakeClient()))
+
+    assert notify_char.uuid in subscribed
+    assert indicate_char.uuid not in subscribed
+    assert service_changed.uuid not in subscribed
+
+
 class Test_ConnectionLifecycle(unittest.IsolatedAsyncioTestCase):
     """Tests for the connect / reconnect lifecycle"""
 

--- a/vvm_to_signalk/ble_connection.py
+++ b/vvm_to_signalk/ble_connection.py
@@ -214,12 +214,19 @@ class BleDeviceConnection:
         """
 
         logger.debug("enabling notifications on data chars")
-        
-        # Iterate over all characteristics in all services and subscribe
+
+        # Subscribe only to "notify" characteristics. The VVM streams all
+        # engine data and fault notifications over notify-type characteristics.
+        # The indicate-type control characteristics it also exposes (e.g.
+        # 0x301/0x302/0x401 and the standard 0x2a05 Service Changed) reject a
+        # CCCD subscribe with ATT error 0x0e and then drop the BLE link, which
+        # stops streaming from ever starting. Subscribing to "indicate" here
+        # therefore breaks the whole connection, so it is intentionally omitted.
+        # Regression: test_setup_data_notifications_skips_indicate_only.
         for service in client.services:
             for characteristic in service.characteristics:
                 props = characteristic.properties
-                if "notify" in props or "indicate" in props:
+                if "notify" in props:
                     try:
                         await client.start_notify(characteristic.uuid, self.notification_handler)
                         logger.debug("Subscribed to %s", characteristic.uuid)


### PR DESCRIPTION
## Problem
On the boat, the connector connected to the VVM and read device info fine, but the device **dropped the BLE link during "Configuring data streaming notifications"** — every cycle, 100% deterministic. The first CCCD subscribe returned `ATT error: 0x0e (Unlikely Error)` and the device disconnected, so streaming never started and no engine data reached the app.

## Root cause
#37 widened `_setup_data_notifications` from notify-only to:
```python
if "notify" in props or "indicate" in props:
```
The VVM exposes **indicate-type control characteristics** (`0x301`/`0x302`/`0x401`, and the standard `0x2a05` Service Changed). Subscribing to those makes the firmware reject the CCCD write with ATT 0x0e and drop the connection. Before #37 (notify-only) it streamed reliably for months.

This was diagnosed live by ruling out the network/SignalK leg, host adapter, a VVM power-cycle, firmware (unchanged 1.8.0-143), BlueZ cache, ignition state, and even a stray second `bluetoothd` — then diffing the function back to before #37.

## Fix
Subscribe to `notify` characteristics only. All engine data and fault notifications arrive on notify-type characteristics, so functionality is unchanged; the broken indicate subscriptions are dropped.

## Test
Adds `test_setup_data_notifications_skips_indicate_only` — asserts a notify char is subscribed while indicate-only chars (incl. `0x2a05`) are not. Verified it **fails** on the old condition and passes on the fix. Full suite: 106 passed.

## Verified on the boat
Hot-patching the running container to notify-only immediately restored stable streaming — 0 disconnects, live RPM/temp/voltage into the CSV and `propulsion.*` in SignalK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)