### PR TITLE
Upgrade bleak 0.22.3 → 3.0.2 (supersedes #44)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-bleak==0.22.3
+bleak==3.0.2
 PyYAML==6.0.3
 websockets==15.0.1


### PR DESCRIPTION
Supersedes #44 (Dependabot), which bumped the pin in `requirements.txt` only. This carries the same bump but **verified against our BLE code** rather than merged blind, since 0.22→3.0 crosses two major versions.

## Verification (throwaway venv, `bleak==3.0.2`)
- **No code changes needed.** Every import we depend on still resolves in 3.x: `bleak.backends.characteristic.BleakGATTCharacteristic`, `bleak.uuids.{normalize_uuid_16, uuid16_dict}`, `bleak.exc.BleakCharacteristicNotFoundError`. Our `start_notify` / `write_gatt_char` / `read_gatt_char` / `client.services` usage and the notification-handler signature are all still compatible.
- **Full test suite: 106 passed.**
- **Notify path unchanged for us.** bleak 2.0 switched BlueZ to `AcquireNotify` by default, which was a concern given the VVM's sensitivity on the notify path (#43). But 3.0.2 **defaults back to `StartNotify`** (`bluez use_start_notify=True`) — same mechanism as 0.22.3. No behavior change unless explicitly opted out.
- `adapter`-kwarg deprecation (3.0) doesn't apply — we don't use it.

## ⚠️ Not yet hardware-validated
The test suite mocks bleak, so it can't exercise real BLE against the VVM. **Do not promote to a release tag / the `:1` image until validated on the boat with the engine running:** stage via `:edge`, confirm a clean `Configuring → Enabling data streaming` with zero disconnects, then release.

Closes #44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)