### PR TITLE
Subscribe to Fault Alert (0x201) + log unparseable channel data

### DIFF
--- a/docs/superpowers/plans/2026-07-12-fault-alert-subscription.md
+++ b/docs/superpowers/plans/2026-07-12-fault-alert-subscription.md
@@ -1,0 +1,375 @@
+# Fault Alert (0x201) subscription + safe fallback — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Subscribe to the Vessel View Mobile Fault Alert characteristic (`0x201`) so async engine faults reach the logs and SignalK, with an in-memory fallback that disables the subscription if it drops the BLE link.
+
+**Architecture:** Add a targeted, isolated `0x201` indicate-subscription that runs *after* streaming is enabled (mirroring the native app's btsnoop-verified order). Guard it with two in-memory flags: `_fault_subscribe_disabled` (skip on subsequent connects this run) and `_fault_subscribe_pending` (in-flight marker for a backstop). A subscribe that raises — or a link drop that races the CCCD ack — disables faults for the rest of the process run while engine-data streaming continues; a container restart re-tries.
+
+**Tech Stack:** Python 3, `bleak` (already a dependency — `start_notify` auto-selects indications for an indicate-only characteristic), `pytest`.
+
+**Spec:** `docs/superpowers/specs/2026-07-10-fault-alert-subscription-design.md`
+
+## Global Constraints
+
+- `_setup_data_notifications` stays **notify-only**; never subscribe to `0x301`/`0x302`/`0x401`/`0x2a05`. Preserve `test_setup_data_notifications_skips_indicate_only`.
+- Subscribe to `0x201` **after** `_set_streaming_mode(enabled=True)` (native-app order).
+- Fallback state is **in-memory only** (no disk persistence). `_fault_subscribe_disabled` is set in `__init__` and never reset within `run()`, so a process restart re-tries.
+- **Disable after 1** failed attempt (subscribe raises, or drop while pending).
+- **No new dependencies.** Use the existing `bleak` client and `UUIDs.DEVICE_201_UUID`.
+- The `0x201` decode path already exists (`notification_handler` → `_handle_fault_notification` → `parse_fault` → `accept_fault`); this plan only adds the missing subscription. Do not modify the decode path.
+
+---
+
+### Task 1: Fault-subscribe state + `_subscribe_fault_alert` helper
+
+**Files:**
+- Modify: `vvm_to_signalk/ble_connection.py` — `__init__` (add two flags); add `_subscribe_fault_alert` method
+- Test: `tests/test_blelogic.py`
+
+**Interfaces:**
+- Produces:
+  - Instance flags `self._fault_subscribe_disabled: bool` and `self._fault_subscribe_pending: bool`
+  - `async def _subscribe_fault_alert(self, client) -> None` — subscribes to `UUIDs.DEVICE_201_UUID`; never raises; sets `_fault_subscribe_disabled` on failure; leaves `_fault_subscribe_pending` False on every return path that completes.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_blelogic.py` (above the `if __name__ == "__main__":` block):
+
+```python
+FAULT_UUID = "00000201-0000-1000-8000-ec55f9f5b963"
+
+
+def _fresh_conn():
+    """A connection on a fresh event loop (prior IsolatedAsyncioTestCase may
+    have closed the loop; __init__ creates an asyncio.Future)."""
+    asyncio.set_event_loop(asyncio.new_event_loop())
+    return BleDeviceConnection(BleConnectionConfig({"name": "x"}), {})
+
+
+def test_fault_alert_subscribes_when_enabled():
+    """When not disabled, the helper subscribes to 0x201 and leaves clean state."""
+    conn = _fresh_conn()
+    subscribed = []
+
+    class FakeClient:
+        async def start_notify(self, uuid, _handler):
+            subscribed.append(uuid)
+
+    asyncio.get_event_loop().run_until_complete(conn._subscribe_fault_alert(FakeClient()))
+    assert FAULT_UUID in subscribed
+    assert conn._fault_subscribe_disabled is False
+    assert conn._fault_subscribe_pending is False
+
+
+def test_fault_alert_subscribe_failure_disables_and_skips_next():
+    """A rejected CCCD write (the #37 ATT 0x0e) must be swallowed, disable the
+    subscription, and cause the next attempt to skip start_notify entirely."""
+    conn = _fresh_conn()
+    calls = []
+
+    class FailingClient:
+        async def start_notify(self, uuid, _handler):
+            calls.append(uuid)
+            raise Exception("ATT error 0x0e (Unlikely Error)")
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(conn._subscribe_fault_alert(FailingClient()))  # must not raise
+    assert conn._fault_subscribe_disabled is True
+    assert conn._fault_subscribe_pending is False
+    # Second attempt: disabled -> start_notify not called again
+    loop.run_until_complete(conn._subscribe_fault_alert(FailingClient()))
+    assert calls == [FAULT_UUID]
+
+
+def test_fault_alert_skipped_when_disabled():
+    """A pre-disabled connection never touches 0x201."""
+    conn = _fresh_conn()
+    conn._fault_subscribe_disabled = True
+    called = []
+
+    class FakeClient:
+        async def start_notify(self, uuid, _handler):
+            called.append(uuid)
+
+    asyncio.get_event_loop().run_until_complete(conn._subscribe_fault_alert(FakeClient()))
+    assert called == []
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_blelogic.py -k fault_alert -v`
+Expected: FAIL — `AttributeError: 'BleDeviceConnection' object has no attribute '_subscribe_fault_alert'` (and `_fault_subscribe_disabled`).
+
+- [ ] **Step 3: Add the state flags in `__init__`**
+
+In `vvm_to_signalk/ble_connection.py`, find these lines in `__init__` (around line 39-41):
+
+```python
+        self._active_engine_ids = None   # set from data-item 10000
+        self._last_active_ids = None     # set from runtime channel-map parse
+        self._unparsed_seen = set()      # channel keys already warned about this connection
+```
+
+Add immediately after them:
+
+```python
+        # Fault Alert (0x201) subscription fallback state (in-memory, per process run).
+        self._fault_subscribe_disabled = False  # set True after a subscribe drops the link
+        self._fault_subscribe_pending = False   # True only between attempting and confirming
+```
+
+- [ ] **Step 4: Add the `_subscribe_fault_alert` helper**
+
+In `vvm_to_signalk/ble_connection.py`, add this method immediately after `_request_offline_fault_channels` (i.e. right before `def notification_handler`, around line 257):
+
+```python
+    async def _subscribe_fault_alert(self, client):
+        """Subscribe to Fault Alert (0x201) indications.
+
+        The native app enables these indications *after* stream-start (verified
+        from the btsnoop capture), so the caller invokes this after
+        _set_streaming_mode. 0x201 is indicate-only; bleak.start_notify
+        auto-selects indications. The CCCD write is an acknowledged ATT Write
+        Request, so a device rejection (the #37 ATT 0x0e failure that drops the
+        link) surfaces as an exception here. On any failure we disable fault
+        subscription for the rest of this process run so engine-data streaming
+        still works; a restart re-tries it.
+        """
+        if self._fault_subscribe_disabled:
+            logger.info("Fault Alert (0x201) subscription disabled this run; skipping")
+            return
+        self._fault_subscribe_pending = True
+        try:
+            await client.start_notify(UUIDs.DEVICE_201_UUID, self.notification_handler)
+        except Exception as e:
+            logger.warning("Fault Alert (0x201) subscribe failed (%s); disabling "
+                           "fault subscription for this run", e)
+            self._fault_subscribe_disabled = True
+            self._fault_subscribe_pending = False
+            return
+        logger.info("Subscribed to Fault Alert (0x201) indications")
+        self._fault_subscribe_pending = False
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_blelogic.py -k fault_alert -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add vvm_to_signalk/ble_connection.py tests/test_blelogic.py
+git commit -m "Add isolated Fault Alert (0x201) subscribe helper with disable-on-failure
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: Wire into the connect lifecycle + drop backstop
+
+**Files:**
+- Modify: `vvm_to_signalk/ble_connection.py` — `_device_init_and_loop` (call helper after streaming-enable; call backstop in `finally`); add `_finalize_fault_subscribe_state` method
+- Test: `tests/test_blelogic.py`
+
+**Interfaces:**
+- Consumes: `_subscribe_fault_alert`, `_fault_subscribe_disabled`, `_fault_subscribe_pending` (Task 1)
+- Produces: `def _finalize_fault_subscribe_state(self) -> None` — if `_fault_subscribe_pending` is still True, set `_fault_subscribe_disabled = True`; always clear `_fault_subscribe_pending`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/test_blelogic.py` (above the `if __name__ == "__main__":` block):
+
+```python
+def test_finalize_disables_when_pending():
+    """If a connection ends mid-subscribe (drop raced the ack), the backstop
+    attributes it to 0x201 and disables the subscription."""
+    conn = _fresh_conn()
+    conn._fault_subscribe_pending = True
+    conn._finalize_fault_subscribe_state()
+    assert conn._fault_subscribe_disabled is True
+    assert conn._fault_subscribe_pending is False
+
+
+def test_finalize_noop_when_not_pending():
+    """A healthy session that disconnects later (pending already False) must not
+    disable faults."""
+    conn = _fresh_conn()
+    conn._fault_subscribe_pending = False
+    conn._fault_subscribe_disabled = False
+    conn._finalize_fault_subscribe_state()
+    assert conn._fault_subscribe_disabled is False
+
+
+class Test_FaultSubscribeOrdering(unittest.IsolatedAsyncioTestCase):
+    """The 0x201 subscribe must happen AFTER streaming is enabled (native-app order)."""
+
+    async def test_subscribe_happens_after_streaming_enable(self):
+        config = BleConnectionConfig()
+        config.device_name = "UnitTestRunner"
+        config.streaming_timeout = 0  # no monitor task -> no task_group needed
+        conn = BleDeviceConnection(config, {})
+
+        order = []
+
+        async def noop(*_a, **_k):
+            pass
+
+        async def rec_stream(*_a, **_k):
+            order.append("stream")
+
+        async def rec_fault(*_a, **_k):
+            order.append("fault")
+
+        conn._retrieve_device_info = noop
+        conn._initalize_vvm = noop
+        conn._setup_data_notifications = noop
+        conn._request_offline_fault_channels = noop
+        conn._set_streaming_mode = rec_stream
+        conn._subscribe_fault_alert = rec_fault
+
+        class FakeClient:
+            def __init__(self, device, disconnected_callback=None, timeout=None, **_kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_a):
+                return False
+
+        # Make the "await cancel_signal" return immediately.
+        conn._BleDeviceConnection__cancel_signal.set_result(None)
+
+        with patch("vvm_to_signalk.ble_connection.BleakClient", FakeClient):
+            await conn._device_init_and_loop("fake-device")
+
+        assert order == ["stream", "fault"], order
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_blelogic.py -k "finalize or FaultSubscribeOrdering" -v`
+Expected: FAIL — `AttributeError: ... '_finalize_fault_subscribe_state'` for the finalize tests; the ordering test fails because `_device_init_and_loop` does not yet call `_subscribe_fault_alert` (`order == ["stream"]`).
+
+- [ ] **Step 3: Add the `_finalize_fault_subscribe_state` method**
+
+In `vvm_to_signalk/ble_connection.py`, add this method immediately after `_subscribe_fault_alert` (added in Task 1):
+
+```python
+    def _finalize_fault_subscribe_state(self):
+        """Backstop for the fault-subscribe fallback: if a connection ended
+        while a 0x201 subscribe was still in flight (a link drop raced the CCCD
+        ack without raising in _subscribe_fault_alert), attribute the drop to
+        the subscribe and disable it for the rest of this run."""
+        if self._fault_subscribe_pending:
+            logger.warning("Connection ended during Fault Alert (0x201) subscribe; "
+                           "disabling fault subscription for this run")
+            self._fault_subscribe_disabled = True
+        self._fault_subscribe_pending = False
+```
+
+- [ ] **Step 4: Call the helper after streaming-enable**
+
+In `_device_init_and_loop`, find (around line 143-144):
+
+```python
+                logger.info("Enabling data streaming from BLE device")
+                await self._set_streaming_mode(client, enabled=True)
+```
+
+Insert immediately after it (before the `# Start the streaming monitor` block):
+
+```python
+
+                # Subscribe to Fault Alert (0x201) indications AFTER streaming is
+                # enabled, mirroring the native app (btsnoop capture). Isolated so
+                # a device that rejects it disables faults but keeps streaming.
+                await self._subscribe_fault_alert(client)
+```
+
+- [ ] **Step 5: Call the backstop in `finally`**
+
+In `_device_init_and_loop`, find the `finally` block (around line 158-161):
+
+```python
+        finally:
+            if monitor_task:
+                monitor_task.cancel()
+            self.__cancel_signal = asyncio.Future()
+```
+
+Change it to call the backstop first:
+
+```python
+        finally:
+            self._finalize_fault_subscribe_state()
+            if monitor_task:
+                monitor_task.cancel()
+            self.__cancel_signal = asyncio.Future()
+```
+
+- [ ] **Step 6: Run the new tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_blelogic.py -k "finalize or FaultSubscribeOrdering" -v`
+Expected: PASS (3 tests).
+
+- [ ] **Step 7: Run the full suite (no regressions)**
+
+Run: `python3 -m pytest -q`
+Expected: PASS — all tests green (the pre-existing `DeprecationWarning: There is no current event loop` is unrelated and acceptable).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add vvm_to_signalk/ble_connection.py tests/test_blelogic.py
+git commit -m "Subscribe to Fault Alert (0x201) after streaming, with drop backstop
+
+Wires the fault subscription into the connect lifecycle in native-app
+order (after stream-start) and disables it if a connection drops while
+the subscribe is still in flight.
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: Live validation on the boat (manual, post-merge)
+
+**Not a code task.** Perform after Tasks 1-2 are merged to `main` and a `vX.Y.Z` tag is pushed (the boat's `:1` image updates only on a semver tag). See the boat deployment notes.
+
+- [ ] **Step 1: Ship the image**
+
+Merge `fault-visibility` to `main`, push a `vX.Y.Z` tag, then on the boat:
+
+```bash
+ssh ryan@boat-searayspx 'cd /opt/stacks/boatpi && docker compose pull vvm && docker compose up -d vvm'
+```
+
+- [ ] **Step 2: Confirm the subscribe succeeds and streaming stays up**
+
+Watch several connect cycles:
+
+```bash
+ssh ryan@boat-searayspx 'tail -f /opt/stacks/boatpi/vvm/logs/vvm_monitor.log'
+```
+
+Expected: `Subscribed to Fault Alert (0x201) indications`, followed by continuous data (`Active engines: ...`, no `Device error` / disconnect loop). Confirm the CSV keeps growing (`data.csv`).
+
+- [ ] **Step 3: Confirm the fallback (only if the device rejects 0x201)**
+
+If instead you see `Fault Alert (0x201) subscribe failed (...); disabling fault subscription for this run`, confirm the *next* reconnect streams engine data normally and does not loop. This is the safe-degradation path; capture the exact error and stop — it means `0x201` indicate-subscribe is not safe on this firmware and the design's assumption needs revisiting.
+
+- [ ] **Step 4: Confirm a real fault is captured**
+
+When a fault is present (or next occurs), expect a `Fault received: Fault(...)` INFO line and a SignalK `notifications.propulsion.<engine>.vvmFault.<key>` delta. Human-readable text is not available offline (cloud-dependent, protocol-map §3.5) — code/position/active-state are.
+
+---
+
+## Notes for the implementer
+
+- `UUIDs.DEVICE_201_UUID` already exists (`vvm_to_signalk/ble_connection.py`, in the `UUIDs` class) and is already used by `notification_handler`.
+- Do **not** add `0x201` to `_setup_data_notifications`; it must stay notify-only. The whole point is that `0x201` is handled separately, after streaming.
+- The ordering test patches `BleakClient` and stubs the sub-steps to record call order; it relies on `config.streaming_timeout = 0` so no `task_group` is needed, and resolves the private `__cancel_signal` future so the connect loop returns immediately.

--- a/docs/superpowers/specs/2026-07-10-fault-alert-subscription-design.md
+++ b/docs/superpowers/specs/2026-07-10-fault-alert-subscription-design.md
@@ -1,0 +1,143 @@
+# Fault Alert (0x201) subscription + safe fallback — design
+
+**Date:** 2026-07-10
+**Branch:** `fault-visibility` (off `main`)
+**Status:** Design, pending implementation plan
+
+## Problem
+
+Real engine faults raised by the engines this season (e.g. "low gear lube",
+"service engine light not connected") never reached SignalK or the logs. Both
+are async SmartCraft fault codes delivered as BLE **indications** on the Fault
+Alert characteristic `0x201`. The connector never subscribes to `0x201`, so the
+fully-built fault decode path (`notification_handler` → `_handle_fault_notification`
+→ `parse_fault` → `accept_fault`) never fires — `Fault received` has never
+appeared in any retained log.
+
+### Root cause
+
+- `_setup_data_notifications` subscribes only where `"notify" in props`. `0x201`
+  is **indicate-only**, so it is skipped.
+- This is fallout from the #37 → #43 sequence: #37 tried to add fault support by
+  subscribing to *all* indicate characteristics, which made the VVM reject the
+  CCCD write on the control characteristics (`0x301/0x302/0x401/0x2a05`) with
+  `ATT 0x0e` and drop the link (no engine data). #43 fixed the outage by
+  reverting to **notify-only**, which also dropped the one indicate char we
+  actually want — `0x201`. Fault support was collateral damage.
+
+The offline-fault items (87 Guardian Cause / 97 Seven-Function-Gauge / 106 MIL)
+that the connector polls are enum/bitfield summaries and do **not** carry these
+specific codes, so they would not have caught these faults either.
+
+## Native-app validation (done)
+
+Parsed `docs/bt-logs/btsnoop_hci.log` (+ `.last.log`) — pure-stdlib btsnoop/HCI/
+L2CAP/ATT parser — to extract the app's exact CCCD writes. Findings (identical
+in both captures, repeated every connection cycle):
+
+```
+0x0016 ModuleCmd CCCD  = 0200   (indicate-enable)
+0x0015 ModuleCmd       = 0d00   (stop stream)
+0x0015 ModuleCmd       = 28000301 (request channel map)
+0x005f Fault CCCD      = 0000   (DISABLE — clear stale sub)
+0x005a UserVar CCCD    = 0200   (indicate) + item reads 10000/4042/4040
+0x001e..0x004a chan CCCDs = 0100 (notify-enable, 0x102..0x10d)
+0x0015 ModuleCmd       = 0d01   (STREAM START)
+0x005f Fault CCCD      = 0200   (INDICATE-ENABLE)  <-- ~0.6s AFTER stream start
+```
+
+Conclusions:
+1. The app subscribes to `0x201` with **indicate-enable (`0200`)** — confirms the fix.
+2. It enables `0x201` **after** `0d01` stream-start (not before). Our implementation
+   must match this ordering.
+3. The app **never** writes CCCDs of `0x301/0x302/0x401/0x2a05` — confirms those
+   caused the #37 drop and validates keeping them on the skip list.
+4. The app writes `0000` (disable) before enabling. Redundant on our unbonded link
+   (CCCD resets per connect); omitted unless live testing shows otherwise.
+5. CCCD writes are acknowledged ATT Write Requests, so a device rejection surfaces
+   as a synchronous exception — the fallback's failure detection is reliable.
+
+## Design
+
+### Scope
+
+This branch bundles two commits:
+1. **(committed)** Log un-parseable channel notifications, deduped per connection.
+2. Fault Alert `0x201` subscription + safe fallback (this design).
+
+Out of scope (YAGNI): logging offline-item values (87/97/106) on change. The two
+observed faults come via `0x201`, which this covers.
+
+### Subscription change
+
+- `_setup_data_notifications` stays notify-only (still skips the dangerous control
+  chars; existing regression test `test_setup_data_notifications_skips_indicate_only`
+  preserved).
+- Add a targeted subscription to Fault Alert `0x201` **after**
+  `_set_streaming_mode(enabled=True)`, mirroring the app. `bleak.start_notify`
+  auto-selects indications for an indicate-only characteristic.
+- Gate it on an in-memory flag `_fault_subscribe_disabled` (default False).
+- Human-readable fault text is cloud-dependent (protocol-map §3.5); we capture and
+  publish code + engine position + active/cleared + severity/IDs only.
+
+### Fallback state machine (in-memory, disable-after-1, retry-on-restart)
+
+Instance flags:
+- `_fault_subscribe_disabled: bool` — when True, skip `0x201`. Reset only by process
+  restart (in-memory), so a restart re-tries `0x201` and picks up future firmware fixes.
+- `_fault_subscribe_pending: bool` — True only in the window between attempting the
+  `0x201` subscribe and confirming the connection survived it.
+
+Flow (per connection, when not disabled):
+1. After streaming is enabled, set `_fault_subscribe_pending = True`.
+2. `await client.start_notify(0x201, handler)` inside try/except:
+   - **raises** (e.g. `ATT 0x0e`) → log warning, `_fault_subscribe_disabled = True`,
+     `_fault_subscribe_pending = False`. Do not propagate — streaming already runs.
+   - **succeeds** → log `Subscribed to Fault Alert (0x201) indications` at INFO,
+     `_fault_subscribe_pending = False` (the ACK means the CCCD write was accepted).
+3. In `_device_init_and_loop`'s `finally`: if `_fault_subscribe_pending` is still True
+   when the connection ends (a drop raced the ACK without a clean exception), set
+   `_fault_subscribe_disabled = True` and log a warning. Always clear pending.
+
+Attribution window is narrow — `[start_notify(0x201) → its ACK]` — so a healthy
+session that disconnects hours later (pending already False) never disables faults.
+On the next reconnect after a disable, `0x201` is skipped and engine data streams
+normally.
+
+### Observability
+
+- INFO when subscribed; WARNING when a subscribe fails / is disabled.
+- Faults themselves already log at INFO (`Fault received: %s`) and publish a SignalK
+  `notifications.propulsion.<engine>.vvmFault.<key>` delta.
+
+## Testing (TDD)
+
+New tests in `tests/test_blelogic.py`:
+- `0x201` **is** subscribed during connect when not disabled.
+- Ordering: the `0x201` subscribe happens **after** the streaming-enable write.
+- `start_notify(0x201)` raising → `_fault_subscribe_disabled` set, and skipped on the
+  next connect.
+- Drop while `_fault_subscribe_pending` (no clean exception) → disabled set.
+- Successful subscribe clears `_fault_subscribe_pending`, so a later normal disconnect
+  does **not** disable.
+- When disabled, `0x201` is not subscribed.
+- Preserve `test_setup_data_notifications_skips_indicate_only` (control chars skipped).
+
+## Deployment / live validation
+
+1. Merge to `main`, push a `vX.Y.Z` tag (the boat's `:1` image updates only on a
+   semver tag — see boat deployment notes).
+2. `docker compose pull vvm && up -d vvm` on the boat.
+3. Watch several connect cycles: streaming stays up (no `ATT 0x0e` / no drop loop),
+   `Subscribed to Fault Alert (0x201)` appears, and a subsequent fault produces a
+   `Fault received` log + SignalK notification.
+4. If the device rejects `0x201`, confirm the fallback disables it and streaming
+   continues.
+
+## Risks
+
+- **Regression risk:** subscribing to an indicate char is what caused the #37 outage.
+  Mitigated by matching the app exactly (subscribe only `0x201`, only after streaming),
+  the acknowledged-write failure detection, and the disable-after-1 fallback.
+- **False disable:** an unrelated BLE drop inside the narrow pending window could
+  disable faults for the session; recovered automatically on restart (in-memory).

--- a/tests/test_blelogic.py
+++ b/tests/test_blelogic.py
@@ -393,6 +393,72 @@ def test_fault_alert_skipped_when_disabled():
     assert called == []
 
 
+def test_finalize_disables_when_pending():
+    """If a connection ends mid-subscribe (drop raced the ack), the backstop
+    attributes it to 0x201 and disables the subscription."""
+    conn = _fresh_conn()
+    conn._fault_subscribe_pending = True
+    conn._finalize_fault_subscribe_state()
+    assert conn._fault_subscribe_disabled is True
+    assert conn._fault_subscribe_pending is False
+
+
+def test_finalize_noop_when_not_pending():
+    """A healthy session that disconnects later (pending already False) must not
+    disable faults."""
+    conn = _fresh_conn()
+    conn._fault_subscribe_pending = False
+    conn._fault_subscribe_disabled = False
+    conn._finalize_fault_subscribe_state()
+    assert conn._fault_subscribe_disabled is False
+
+
+class Test_FaultSubscribeOrdering(unittest.IsolatedAsyncioTestCase):
+    """The 0x201 subscribe must happen AFTER streaming is enabled (native-app order)."""
+
+    async def test_subscribe_happens_after_streaming_enable(self):
+        config = BleConnectionConfig()
+        config.device_name = "UnitTestRunner"
+        config.streaming_timeout = 0  # no monitor task -> no task_group needed
+        conn = BleDeviceConnection(config, {})
+
+        order = []
+
+        async def noop(*_a, **_k):
+            pass
+
+        async def rec_stream(*_a, **_k):
+            order.append("stream")
+
+        async def rec_fault(*_a, **_k):
+            order.append("fault")
+
+        conn._retrieve_device_info = noop
+        conn._initalize_vvm = noop
+        conn._setup_data_notifications = noop
+        conn._request_offline_fault_channels = noop
+        conn._set_streaming_mode = rec_stream
+        conn._subscribe_fault_alert = rec_fault
+
+        class FakeClient:
+            def __init__(self, device, disconnected_callback=None, timeout=None, **_kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_a):
+                return False
+
+        # Make the "await cancel_signal" return immediately.
+        conn._BleDeviceConnection__cancel_signal.set_result(None)
+
+        with patch("vvm_to_signalk.ble_connection.BleakClient", FakeClient):
+            await conn._device_init_and_loop("fake-device")
+
+        assert order == ["stream", "fault"], order
+
+
 if __name__ == "__main__":
     logging.basicConfig(stream=sys.stderr)
     logging.getLogger().setLevel(logging.DEBUG)

--- a/tests/test_blelogic.py
+++ b/tests/test_blelogic.py
@@ -263,6 +263,77 @@ def test_notification_handler_skips_hex_when_debug_disabled():
         ble_logger.setLevel(old_level)
 
 
+def test_unparsed_channel_data_is_logged_at_warning(caplog):
+    """A channel notification we can't decode (unknown data-item ID) must be
+    surfaced at WARNING with the raw hex, not silently dropped — otherwise a
+    new/unknown item is invisible at the deployed INFO log level."""
+    conn = BleDeviceConnection(BleConnectionConfig({"name": "x"}), {})
+    conn._dictionary = DataDictionary.load()
+    conn._max_engines = 1
+    # id 9999 (0x270F -> LE "0f27") is not in the data dictionary.
+    with caplog.at_level(logging.WARNING, logger="vvm_to_signalk.ble_connection"):
+        conn.notification_handler(FakeChar("00000102-0000-1000-8000-ec55f9f5b963"),
+                                  bytearray.fromhex("0f27" + "abcd"))
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("0f27abcd" in m for m in msgs), msgs
+
+
+def test_unparsed_channel_data_deduped_per_connection(caplog):
+    """The same unknown item must be logged only once per connection even as
+    its value bytes change every notification, so a persistent unknown stream
+    at ~20 Hz doesn't flood the log."""
+    conn = BleDeviceConnection(BleConnectionConfig({"name": "x"}), {})
+    conn._dictionary = DataDictionary.load()
+    conn._max_engines = 1
+    char = FakeChar("00000102-0000-1000-8000-ec55f9f5b963")
+    with caplog.at_level(logging.WARNING, logger="vvm_to_signalk.ble_connection"):
+        conn.notification_handler(char, bytearray.fromhex("0f27" + "abcd"))
+        conn.notification_handler(char, bytearray.fromhex("0f27" + "1234"))
+        conn.notification_handler(char, bytearray.fromhex("0f27" + "0000"))
+    warnings = [r for r in caplog.records if "0f27" in r.getMessage()]
+    assert len(warnings) == 1, [r.getMessage() for r in warnings]
+
+
+def test_distinct_unparsed_items_each_logged(caplog):
+    """Two different unknown item IDs must each be logged once."""
+    conn = BleDeviceConnection(BleConnectionConfig({"name": "x"}), {})
+    conn._dictionary = DataDictionary.load()
+    conn._max_engines = 1
+    char = FakeChar("00000102-0000-1000-8000-ec55f9f5b963")
+    with caplog.at_level(logging.WARNING, logger="vvm_to_signalk.ble_connection"):
+        conn.notification_handler(char, bytearray.fromhex("0f27" + "abcd"))  # id 9999
+        conn.notification_handler(char, bytearray.fromhex("0e27" + "abcd"))  # id 9998
+    assert any("0f27" in r.getMessage() for r in caplog.records)
+    assert any("0e27" in r.getMessage() for r in caplog.records)
+
+
+def test_unparsed_dedup_resets_between_connections(caplog):
+    """The dedup memory is per-connection: after a reconnect the same unknown
+    item is logged again (a fresh connection may reveal it changed)."""
+    conn = BleDeviceConnection(BleConnectionConfig({"name": "x"}), {})
+    conn._dictionary = DataDictionary.load()
+    conn._max_engines = 1
+    char = FakeChar("00000102-0000-1000-8000-ec55f9f5b963")
+    with caplog.at_level(logging.WARNING, logger="vvm_to_signalk.ble_connection"):
+        conn.notification_handler(char, bytearray.fromhex("0f27" + "abcd"))
+        conn._reset_unparsed_tracking()  # what a new connection does
+        conn.notification_handler(char, bytearray.fromhex("0f27" + "abcd"))
+    warnings = [r for r in caplog.records if "0f27" in r.getMessage()]
+    assert len(warnings) == 2, [r.getMessage() for r in warnings]
+
+
+def test_known_item_not_warned(caplog):
+    """A normally-decodable notification must not produce an unparsed warning."""
+    conn = BleDeviceConnection(BleConnectionConfig({"name": "x"}), {})
+    conn._dictionary = DataDictionary.load()
+    conn._max_engines = 1
+    with caplog.at_level(logging.WARNING, logger="vvm_to_signalk.ble_connection"):
+        conn.notification_handler(FakeChar("00000102-0000-1000-8000-ec55f9f5b963"),
+                                  bytearray.fromhex("0100" + "5802"))  # id 1 RPM
+        asyncio.get_event_loop().run_until_complete(asyncio.sleep(0))
+    assert not any("Unparsed" in r.getMessage() for r in caplog.records)
+
+
 if __name__ == "__main__":
     logging.basicConfig(stream=sys.stderr)
     logging.getLogger().setLevel(logging.DEBUG)

--- a/tests/test_blelogic.py
+++ b/tests/test_blelogic.py
@@ -334,6 +334,65 @@ def test_known_item_not_warned(caplog):
     assert not any("Unparsed" in r.getMessage() for r in caplog.records)
 
 
+FAULT_UUID = "00000201-0000-1000-8000-ec55f9f5b963"
+
+
+def _fresh_conn():
+    """A connection on a fresh event loop (prior IsolatedAsyncioTestCase may
+    have closed the loop; __init__ creates an asyncio.Future)."""
+    asyncio.set_event_loop(asyncio.new_event_loop())
+    return BleDeviceConnection(BleConnectionConfig({"name": "x"}), {})
+
+
+def test_fault_alert_subscribes_when_enabled():
+    """When not disabled, the helper subscribes to 0x201 and leaves clean state."""
+    conn = _fresh_conn()
+    subscribed = []
+
+    class FakeClient:
+        async def start_notify(self, uuid, _handler):
+            subscribed.append(uuid)
+
+    asyncio.get_event_loop().run_until_complete(conn._subscribe_fault_alert(FakeClient()))
+    assert FAULT_UUID in subscribed
+    assert conn._fault_subscribe_disabled is False
+    assert conn._fault_subscribe_pending is False
+
+
+def test_fault_alert_subscribe_failure_disables_and_skips_next():
+    """A rejected CCCD write (the #37 ATT 0x0e) must be swallowed, disable the
+    subscription, and cause the next attempt to skip start_notify entirely."""
+    conn = _fresh_conn()
+    calls = []
+
+    class FailingClient:
+        async def start_notify(self, uuid, _handler):
+            calls.append(uuid)
+            raise Exception("ATT error 0x0e (Unlikely Error)")
+
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(conn._subscribe_fault_alert(FailingClient()))  # must not raise
+    assert conn._fault_subscribe_disabled is True
+    assert conn._fault_subscribe_pending is False
+    # Second attempt: disabled -> start_notify not called again
+    loop.run_until_complete(conn._subscribe_fault_alert(FailingClient()))
+    assert calls == [FAULT_UUID]
+
+
+def test_fault_alert_skipped_when_disabled():
+    """A pre-disabled connection never touches 0x201."""
+    conn = _fresh_conn()
+    conn._fault_subscribe_disabled = True
+    called = []
+
+    class FakeClient:
+        async def start_notify(self, uuid, _handler):
+            called.append(uuid)
+
+    asyncio.get_event_loop().run_until_complete(conn._subscribe_fault_alert(FakeClient()))
+    assert called == []
+
+
 if __name__ == "__main__":
     logging.basicConfig(stream=sys.stderr)
     logging.getLogger().setLevel(logging.DEBUG)

--- a/vvm_to_signalk/ble_connection.py
+++ b/vvm_to_signalk/ble_connection.py
@@ -313,7 +313,7 @@ class BleDeviceConnection:
         if logger.isEnabledFor(logging.DEBUG):
             logger.debug("Notification UUID %s data %s", uuid, data.hex())
 
-        # Fault Alert characteristic is handled separately (Task 8).
+        # Fault Alert characteristic is decoded separately (see _handle_fault_notification).
         if uuid == UUIDs.DEVICE_201_UUID:
             self._handle_fault_notification(bytes(data))
             return

--- a/vvm_to_signalk/ble_connection.py
+++ b/vvm_to_signalk/ble_connection.py
@@ -39,6 +39,9 @@ class BleDeviceConnection:
         self._active_engine_ids = None   # set from data-item 10000
         self._last_active_ids = None     # set from runtime channel-map parse
         self._unparsed_seen = set()      # channel keys already warned about this connection
+        # Fault Alert (0x201) subscription fallback state (in-memory, per process run).
+        self._fault_subscribe_disabled = False  # set True after a subscribe drops the link
+        self._fault_subscribe_pending = False   # True only between attempting and confirming
 
     def accept_data_receiver(self, receiver: EngineDataReceiver) -> None:
         """Add a new data receiver to the collection"""
@@ -256,6 +259,33 @@ class BleDeviceConnection:
                 slot += 1
             except Exception as e:
                 logger.warning("Could not request fault item %s on %s: %s", item_id, char_uuid, e)
+
+    async def _subscribe_fault_alert(self, client):
+        """Subscribe to Fault Alert (0x201) indications.
+
+        The native app enables these indications *after* stream-start (verified
+        from the btsnoop capture), so the caller invokes this after
+        _set_streaming_mode. 0x201 is indicate-only; bleak.start_notify
+        auto-selects indications. The CCCD write is an acknowledged ATT Write
+        Request, so a device rejection (the #37 ATT 0x0e failure that drops the
+        link) surfaces as an exception here. On any failure we disable fault
+        subscription for the rest of this process run so engine-data streaming
+        still works; a restart re-tries it.
+        """
+        if self._fault_subscribe_disabled:
+            logger.info("Fault Alert (0x201) subscription disabled this run; skipping")
+            return
+        self._fault_subscribe_pending = True
+        try:
+            await client.start_notify(UUIDs.DEVICE_201_UUID, self.notification_handler)
+        except Exception as e:
+            logger.warning("Fault Alert (0x201) subscribe failed (%s); disabling "
+                           "fault subscription for this run", e)
+            self._fault_subscribe_disabled = True
+            self._fault_subscribe_pending = False
+            return
+        logger.info("Subscribed to Fault Alert (0x201) indications")
+        self._fault_subscribe_pending = False
 
     def notification_handler(self, characteristic: BleakGATTCharacteristic, data: bytearray):
         """Handles BLE notifications and indications."""

--- a/vvm_to_signalk/ble_connection.py
+++ b/vvm_to_signalk/ble_connection.py
@@ -146,6 +146,11 @@ class BleDeviceConnection:
                 logger.info("Enabling data streaming from BLE device")
                 await self._set_streaming_mode(client, enabled=True)
 
+                # Subscribe to Fault Alert (0x201) indications AFTER streaming is
+                # enabled, mirroring the native app (btsnoop capture). Isolated so
+                # a device that rejects it disables faults but keeps streaming.
+                await self._subscribe_fault_alert(client)
+
                 # Start the streaming monitor if a timeout is configured
                 if self.__config.streaming_timeout > 0:
                     monitor_task = self.__task_group.create_task(self._monitor_streaming())
@@ -159,6 +164,7 @@ class BleDeviceConnection:
         except Exception as e:
             self._set_health(False, f"Device error: {e}")
         finally:
+            self._finalize_fault_subscribe_state()
             if monitor_task:
                 monitor_task.cancel()
             self.__cancel_signal = asyncio.Future()
@@ -285,6 +291,17 @@ class BleDeviceConnection:
             self._fault_subscribe_pending = False
             return
         logger.info("Subscribed to Fault Alert (0x201) indications")
+        self._fault_subscribe_pending = False
+
+    def _finalize_fault_subscribe_state(self):
+        """Backstop for the fault-subscribe fallback: if a connection ended
+        while a 0x201 subscribe was still in flight (a link drop raced the CCCD
+        ack without raising in _subscribe_fault_alert), attribute the drop to
+        the subscribe and disable it for the rest of this run."""
+        if self._fault_subscribe_pending:
+            logger.warning("Connection ended during Fault Alert (0x201) subscribe; "
+                           "disabling fault subscription for this run")
+            self._fault_subscribe_disabled = True
         self._fault_subscribe_pending = False
 
     def notification_handler(self, characteristic: BleakGATTCharacteristic, data: bytearray):

--- a/vvm_to_signalk/ble_connection.py
+++ b/vvm_to_signalk/ble_connection.py
@@ -38,6 +38,7 @@ class BleDeviceConnection:
         self._max_engines = 4
         self._active_engine_ids = None   # set from data-item 10000
         self._last_active_ids = None     # set from runtime channel-map parse
+        self._unparsed_seen = set()      # channel keys already warned about this connection
 
     def accept_data_receiver(self, receiver: EngineDataReceiver) -> None:
         """Add a new data receiver to the collection"""
@@ -127,6 +128,7 @@ class BleDeviceConnection:
 
                 self._set_health(True, "Connected to device")
                 connected = True
+                self._reset_unparsed_tracking()
 
                 logger.info("Retrieving device identification metadata...")
                 await self._retrieve_device_info(client)
@@ -277,6 +279,7 @@ class BleDeviceConnection:
 
         item, values = decode_notification(bytes(data), self._dictionary, self._max_engines)
         if item is None:
+            self._log_unparsed_channel_data(uuid, bytes(data))
             return
         if item.id == 10000:
             self._update_active_engines(bytes(data))
@@ -286,6 +289,30 @@ class BleDeviceConnection:
             if self._active_engine_ids is not None and engine_id not in self._active_engine_ids:
                 continue
             self._publish_engine_value(item, engine_id, value)
+
+    def _reset_unparsed_tracking(self):
+        """Clear the per-connection memory of already-warned channel data so a
+        fresh connection re-surfaces any still-undecodable notifications."""
+        self._unparsed_seen.clear()
+
+    def _log_unparsed_channel_data(self, uuid: str, data: bytes):
+        """Surface a channel notification we couldn't decode, once per distinct
+        item-id (or raw payload, if too short to carry one) per connection.
+
+        Channels stream at ~20 Hz and an unknown item's value bytes change on
+        every notification, so we dedup on the item-id rather than the full
+        payload to make novel/unknown data visible without flooding the log.
+        """
+        if len(data) >= 2:
+            key = ("id", int.from_bytes(data[:2], byteorder="little"))
+            what = f"item-id {key[1]}"
+        else:
+            key = ("raw", data.hex())
+            what = "short payload"
+        if key in self._unparsed_seen:
+            return
+        self._unparsed_seen.add(key)
+        logger.warning("Unparsed channel data on %s (%s): %s", uuid, what, data.hex())
 
     def _publish_engine_value(self, item, engine_id, value):
         """Dispatch a decoded engine value to all registered receivers."""


### PR DESCRIPTION
## Why

The check-engine/MIL light is currently on (engine 1), and real faults this season ("low gear lube", "service engine light not connected") never reached the logs or SignalK. Those are async SmartCraft codes delivered as **indications on the Fault Alert characteristic `0x201`** — which the connector never subscribed to. The fault decode path was fully built but had no subscription feeding it (`Fault received` has never appeared in any log).

Root cause: #37 tried to add fault support by subscribing to *all* indicate characteristics, including the control chars (`0x301/0x302/0x401/0x2a05`) that the VVM rejects with `ATT 0x0e` and drops the link. #43 reverted to notify-only to fix that outage, which also removed the one indicate char we want — `0x201`.

## What

1. **Subscribe to `0x201`** (indicate-only) **after** streaming is enabled, mirroring the native app's BLE order — verified against the `docs/bt-logs` btsnoop capture, which also confirmed the app never touches the control-char CCCDs.
2. **Safe fallback:** if the `0x201` subscribe raises (the #37 `ATT 0x0e`) or the link drops while the subscribe is in flight, disable it for the process run (in-memory; a restart re-tries) so engine-data streaming still works even if the device rejects it.
3. **Log unparseable channel notifications** (unknown data-item id / too-short) at WARNING, deduped per connection — closes a silent-drop gap.

## Validation

- 117 tests pass; `_setup_data_notifications` stays notify-only (regression test preserved).
- Design spec + implementation plan under `docs/superpowers/`.
- Multi-agent review: regression safety, fallback state machine (incl. asyncio-cancel / disconnect-race), dedup correctness — all clean.

Post-merge: tag `v1.1.0`, pull `:1` on the boat, confirm the MIL fault is captured as `Fault received` + a `vvmFault` SignalK notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)