### PR TITLE
Map known fault codes to human-readable text

### DIFF
--- a/tests/test_fault_decoder.py
+++ b/tests/test_fault_decoder.py
@@ -1,4 +1,4 @@
-from vvm_to_signalk.fault_decoder import parse_fault
+from vvm_to_signalk.fault_decoder import parse_fault, Fault
 
 def test_legacy_fault():
     # byte0: type=2 (Legacy) low nibble, engine=1 high nibble -> 0x12
@@ -31,3 +31,20 @@ def test_universal_fault_bitfields():
 
 def test_bad_length_returns_none():
     assert parse_fault(bytes.fromhex("0000")) is None
+
+def test_known_fault_description():
+    # 946-6 is a known code (native app: "Emissions Control Fault").
+    f = Fault("Universal", 1, True, 946, failure_type_id=6)
+    assert f.fault_key == "946-6"
+    assert f.description == "Emissions Control Fault"
+
+def test_unknown_fault_description_is_none():
+    f = Fault("Legacy", 1, True, 1111)
+    assert f.fault_key == "1111-Legacy"
+    assert f.description is None
+
+def test_str_includes_description_only_when_known():
+    known = Fault("Universal", 1, True, 946, failure_type_id=6)
+    assert 'desc="Emissions Control Fault"' in str(known)
+    unknown = Fault("Legacy", 1, True, 1111)
+    assert "desc=" not in str(unknown)

--- a/tests/test_signalk_publisher.py
+++ b/tests/test_signalk_publisher.py
@@ -36,6 +36,25 @@ def test_accept_fault_cleared_is_normal():
     assert delta["value"]["method"] == []
 
 
+def test_accept_fault_message_includes_known_description():
+    pub = SignalKPublisher(SignalKConfig({"websocket-url": "ws://x"}), {})
+    ws = FakeWS(); pub._SignalKPublisher__websocket = ws; pub.socket_connected = True
+    asyncio.run(pub.accept_fault(Fault("Universal", 1, True, 946, failure_type_id=6)))
+    delta = ws.sent[0]["updates"][0]["values"][0]
+    assert "Emissions Control Fault" in delta["value"]["message"]
+    assert "946-6" in delta["value"]["message"]
+    assert delta["value"]["vvm"]["description"] == "Emissions Control Fault"
+
+
+def test_accept_fault_message_bare_code_when_unknown():
+    pub = SignalKPublisher(SignalKConfig({"websocket-url": "ws://x"}), {})
+    ws = FakeWS(); pub._SignalKPublisher__websocket = ws; pub.socket_connected = True
+    asyncio.run(pub.accept_fault(Fault("Legacy", 1, True, 1111)))
+    delta = ws.sent[0]["updates"][0]["values"][0]
+    assert "1111-Legacy" in delta["value"]["message"]
+    assert delta["value"]["vvm"]["description"] is None
+
+
 class FakeItem:
     """Minimal stand-in for DataItem used in publisher tests."""
     def __init__(self, item_id=1, name="RPM", units="revs/minute", is_vessel=False):

--- a/vvm_to_signalk/fault_decoder.py
+++ b/vvm_to_signalk/fault_decoder.py
@@ -5,6 +5,14 @@ logger = logging.getLogger(__name__)
 
 _FAULT_TYPES = {0: "Unknown", 1: "Universal", 2: "Legacy"}
 
+# Human-readable text for known fault codes, keyed by `fault_key`. Mercury
+# resolves fault text through a cloud API (protocol-map.md §3.5) with no offline
+# dictionary, so this is a hand-maintained map of codes identified from the
+# native app. Unknown codes fall back to the bare key.
+FAULT_TEXT = {
+    "946-6": "Emissions Control Fault",
+}
+
 
 class Fault:
     """A decoded engine fault event."""
@@ -20,14 +28,21 @@ class Fault:
         self.action_id = action_id
 
     def __str__(self):
+        desc = self.description
+        desc_part = f', desc="{desc}"' if desc else ""
         return (f"Fault(type={self.fault_type}, engine={self.engine_position}, "
-                f"active={self.is_active}, key={self.fault_key})")
+                f"active={self.is_active}, key={self.fault_key}{desc_part})")
 
     @property
     def fault_key(self) -> str:
         if self.fault_type == "Universal":
             return f"{self.fault_id}-{self.failure_type_id}"
         return f"{self.fault_id}-Legacy"
+
+    @property
+    def description(self) -> str | None:
+        """Human-readable text for this fault code, or None if not in FAULT_TEXT."""
+        return FAULT_TEXT.get(self.fault_key)
 
 
 def _common_header(data: bytes):

--- a/vvm_to_signalk/signalk_publisher.py
+++ b/vvm_to_signalk/signalk_publisher.py
@@ -247,16 +247,22 @@ class SignalKPublisher:
         """Publish a fault as a SignalK notification delta."""
         label = engine_label(fault.engine_position, self.__config.engine_labels)
         path = f"notifications.propulsion.{label}.vvmFault.{fault.fault_key}"
+        description = fault.description
+        message = f"Engine {fault.engine_position} fault {fault.fault_key}"
+        if description:
+            message += f": {description}"
+        if not fault.is_active:
+            message += " cleared"
         value = {
             "state": "alarm" if fault.is_active else "normal",
             "method": ["visual", "sound"] if fault.is_active else [],
-            "message": f"Engine {fault.engine_position} fault {fault.fault_key}"
-                       + ("" if fault.is_active else " cleared"),
+            "message": message,
             "vvm": {
                 "faultId": fault.fault_id,
                 "failureTypeId": fault.failure_type_id,
                 "severity": fault.severity,
                 "type": fault.fault_type,
+                "description": description,
             },
         }
         if self.socket_connected:


### PR DESCRIPTION
Follow-up to #46. Faults are now captured by code (e.g. `946-6`), but Mercury keeps the human text behind their cloud (no offline dictionary — protocol-map §3.5).

Adds a small hand-maintained `FAULT_TEXT` map keyed by `fault_key`, so captured faults log and publish with a name. Seeded with `946-6 = "Emissions Control Fault"` (identified from the native app — this is the fault currently active on engine 1). Unknown codes fall back to the bare key.

Enriches: the `Fault received:` log line (via `Fault.__str__`), the SignalK notification `message`, and a structured `vvm.description` field (null when unknown).

122 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)