### PR TITLE
Upgrade bleak to 3.0.2 (integrated with fault-visibility)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-bleak==0.22.3
+bleak==3.0.2
 PyYAML==6.0.3
 websockets==15.0.1


### PR DESCRIPTION
Integrates the bleak 0.22.3 → 3.0.2 upgrade (previously the standalone `bleak-3-upgrade` branch, just a `requirements.txt` bump) on top of current `main`, which now includes the fault subscription (#46) and fault-text map (#47).

**Validation so far (static):**
- All bleak import sites resolve under 3.0.2 (`BleakClient/BleakScanner`, `bleak.backends.characteristic.BleakGATTCharacteristic`, `bleak.uuids.normalize_uuid_16`/`uuid16_dict`, `bleak.exc.BleakCharacteristicNotFoundError`).
- Full test suite (122) passes under bleak 3.0.2.

**Still to validate:** real-hardware BLE behaviour on the boat (scan/connect/notify + the `0x201` indicate subscribe + streaming) — deploying the `pr-` image temporarily before promoting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)