### PR TITLE
BLE GATT proxy: native-app coexistence + traffic capture (opt-in)

### DIFF
--- a/docs/ble-gatt-proxy-hardware-test-plan.md
+++ b/docs/ble-gatt-proxy-hardware-test-plan.md
@@ -1,0 +1,155 @@
+# BLE GATT Proxy — Hardware Test Plan (boat runbook)
+
+Self-contained procedure to validate the BLE GATT proxy on the boat. Pick this up
+when the engine/VVM is **powered on**; nothing here depends on the session that wrote it.
+
+- Feature: single-radio transparent BLE GATT proxy so the native SmartCraft app and the
+  connector can both use the VVM over its one BLE connection slot.
+- Design: [`docs/superpowers/specs/2026-07-20-ble-gatt-proxy-design.md`](superpowers/specs/2026-07-20-ble-gatt-proxy-design.md)
+- Plan: [`docs/superpowers/plans/2026-07-20-ble-gatt-proxy.md`](superpowers/plans/2026-07-20-ble-gatt-proxy.md)
+- Branch / PR: `ble-gatt-proxy` / **PR #52 (draft)**. All host-testable code is done + reviewed;
+  196 unit tests green. **Do not mark the PR ready or merge until both gates below pass.**
+- Test image (already built + smoke-tested by CI): **`rgregg/vvm_monitor:pr-52`** (multi-arch, incl. arm64).
+- VVM BLE address used below: `84:FD:27:D9:2C:BE` (substitute your device's address if different).
+
+Deployment specifics (how to reach the Pi, the compose stack path/service name) are intentionally
+not in this public doc — use your normal boat deployment process. The steps below say *what* to
+change; apply them with your usual `docker compose` workflow for the connector service.
+
+---
+
+## Prerequisites
+
+- [ ] Engine / VVM **powered on** and advertising (this whole plan is meaningless with it off).
+- [ ] Boat Pi reachable; connector currently running on `:1` (= v1.3.0).
+- [ ] A phone with the native SmartCraft / VesselView Mobile app, logged in, near the boat.
+- [ ] The Pi's Bluetooth controller supports concurrent roles — already confirmed via BlueZ
+      (`bluetoothctl show` → `Roles: central` + `Roles: peripheral`). Gate 1 proves it holds
+      *while a VVM connection is open*, which is the part that can't be confirmed off-hardware.
+
+---
+
+## Gate 1 — Concurrency spike (single-radio go/no-go)
+
+**Goal:** prove the onboard radio can advertise a peripheral *while* holding the VVM central
+connection. This isolates "the radio can't do concurrent roles" (→ dual-adapter fallback) from
+"a bug in the proxy logic" — run it before the full E2E so a failure is unambiguous.
+
+The spike must be the only thing using the radio, so **stop the connector first** (it would
+otherwise hold the VVM's single slot and fight the spike).
+
+```bash
+# 1) Stop the connector so it releases the VVM BLE connection.
+#    (your normal: docker compose stop <connector service>)
+
+# 2) Fetch the spike tool from the public branch (it is NOT baked into the image).
+curl -fsSL -o /tmp/proxy_concurrency_spike.py \
+  https://raw.githubusercontent.com/rgregg/signalk-vvm-ble-connector/ble-gatt-proxy/tools/proxy_concurrency_spike.py
+
+# 3) Run it inside the pr-52 image (has bleak + bless + bluez), with host D-Bus + networking
+#    so it talks to the host bluetoothd exactly like the connector does.
+docker run --rm -it --net host \
+  -v /run/dbus/system_bus_socket:/run/dbus/system_bus_socket \
+  -v /tmp/proxy_concurrency_spike.py:/app/spike.py:ro \
+  rgregg/vvm_monitor:pr-52 \
+  python -u /app/spike.py --address 84:FD:27:D9:2C:BE --hold 60
+```
+
+**Expected GO output:**
+```
+... CENTRAL connected to VVM 84:FD:27:D9:2C:BE
+... PERIPHERAL advertising as VVM_SPIKE_TEST -- both roles now live
+... Holding both for 60s; watch for disconnects/errors...
+... GO: both roles held for the full window with no error
+```
+While it holds, confirm on the phone (a generic BLE scanner, e.g. nRF Connect) that
+`VVM_SPIKE_TEST` is visible **at the same time** the central is connected.
+
+**Decision:**
+- **GO** — both roles held 60s, no error, `VVM_SPIKE_TEST` seen while connected → proceed to Gate 2.
+- **NO-GO** — advertising rejected while connected, or the VVM link drops when advertising starts,
+  or an HCI/BlueZ error → **stop.** Single-radio (Approach A) is not viable on this hardware;
+  switch to the **dual-adapter fallback** documented in the design spec (add a USB BLE dongle;
+  central on `hci0`, peripheral on `hci1`). Do not merge the PR. Record the exact error.
+
+Afterward, restart the connector on `:1` if you want data flowing before Gate 2, or go straight
+into Gate 2 (which replaces the running image anyway).
+
+---
+
+## Gate 2 — End-to-end proxy on the boat
+
+**Goal:** with the proxy actually running, confirm (a) the connector still feeds SignalK,
+(b) the native app connects **through the proxy** and shows live engine data, (c) all relayed
+traffic is captured, and (d) the forwarded indicate-subscribes don't drop the upstream link.
+
+### Deploy the test image with the proxy enabled
+
+1. Point the connector service's image at **`rgregg/vvm_monitor:pr-52`** (back up the current
+   compose first; today it's `:1`).
+2. Add this block to the connector's `config/vvm_monitor.yaml` (the proxy is **off** unless present):
+   ```yaml
+   proxy:
+     enabled: true
+     capture-file: ./logs/ble_capture.log
+     # advertised-name defaults to ble-device.name; set explicitly if you want:
+     # advertised-name: "VVM_84FD27D92CBE"
+   ```
+3. Pull + recreate the connector (`docker compose pull` + `up -d` for the service), then tail its log.
+
+### Checks
+
+- [ ] **(a) Proxy came up.** Connector log shows, on connect:
+      `BLE GATT proxy enabled (advertising as VVM_...)` then `Proxy relay active (advertising VVM_...)`.
+- [ ] **(b) SignalK still flowing.** On the Pi: `curl -s http://localhost:3000/signalk/v1/api/vessels/self/propulsion | head`
+      shows values updating (RPM/temp/etc.) — the proxy must not have starved the connector's own feed.
+- [ ] **(c) App connects through the proxy.** On the phone, open the native app, pick `VVM_...`
+      from the scan list (only our peripheral should appear — the real VVM isn't advertising while
+      we hold its slot), and confirm it connects and shows **live** engine data (RPM changing,
+      temps, fuel). Device-info fields (model/firmware) should be populated, not blank.
+- [ ] **(d) Capture populating.** `logs/ble_capture.log` grows with both `app->vvm` and `vvm->app`
+      lines (timestamped hex). This is the protocol-capture deliverable.
+
+### Indicate-subscribe check (settles the #37 question)
+
+The native app subscribes (CCCD) to the indicate control chars `0x0301 / 0x0302 / 0x0401 / 0x2a05`.
+Those subscribes historically dropped the link for *our* connector (issue #37) but the app does
+them fine. The proxy forwards the app's exact sequence.
+
+- [ ] Right after the app connects, watch the connector log for an upstream drop
+      (`BLE device disconnected` / return to scan loop) coinciding with the app's subscribes.
+- [ ] In `logs/ble_capture.log`, find the app's `write`/`subscribe` lines to `...0301/0302/0401/2a05`.
+      If the VVM link drops immediately after one specific CCCD, **note which UUID** — the follow-up
+      is to add a deny-list in `ProxyRelay._forward_write` that stops forwarding just that one
+      (the app still gets data). If nothing drops, #37 was a client-side ordering quirk, now moot.
+
+### Data to capture (paste back / save to `~/vvm-fault-docs/` or the PR)
+
+1. Gate 1 spike output (GO / exact NO-GO error).
+2. Connector log excerpt covering one full connect (proxy-active line through steady streaming),
+   and any disconnects.
+3. First ~200 lines of `logs/ble_capture.log` (the app's connect handshake — useful for the
+   fault-code / native-client RE effort regardless of outcome).
+4. Whether the native app showed live data (y/n) and whether any field was blank.
+5. Whether/which forwarded CCCD dropped the link.
+
+---
+
+## Rollback (return the boat to stable at any point)
+
+1. Repoint the connector image from `:pr-52` back to **`:1`** (= v1.3.0 — this is safe; `:1`
+   already contains everything in main incl. #49).
+2. Remove (or set `enabled: false` in) the `proxy:` block in `config/vvm_monitor.yaml`.
+3. `docker compose pull` + `up -d` the connector. Confirm normal streaming + SignalK.
+
+---
+
+## On GO (both gates pass)
+
+1. Save the captured artifacts and note results in the PR (#52) and the design spec.
+2. Mark **PR #52 ready for review** and merge to `main`.
+3. Cut a semver tag (e.g. `v1.4.0`) on `main` → CI publishes `1.4.0/1.4/1/latest`.
+4. Repoint the boat from the `pr-52` test image to the released `:1` and keep `proxy.enabled: true`.
+5. Follow-ups noted in the design/plan (non-blocking): parallelize connect-time pre-reads;
+   add regression tests for the off-loop/`main()` wiring branches; harden write-arbitration once
+   the capture shows real app behavior.

--- a/docs/superpowers/plans/2026-07-20-ble-gatt-proxy.md
+++ b/docs/superpowers/plans/2026-07-20-ble-gatt-proxy.md
@@ -1,0 +1,1243 @@
+# BLE GATT Proxy Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let the native SmartCraft app and the connector both use the VVM over its single BLE connection slot, by making the connector a transparent BLE GATT proxy (peripheral to the app, central to the VVM) that also captures all relayed traffic.
+
+**Architecture:** One process, two BLE roles on `hci0`. The existing `bleak` central (`BleDeviceConnection`) holds the VVM link and keeps feeding SignalK. A new `bless` peripheral (`VvmProxyPeripheral`) clones the VVM's GATT profile and lets the app connect. A `ProxyRelay` forwards notifications VVM→app and writes/subscribes/reads app→VVM, and a `TrafficCapture` logs every relayed op. Everything is behind an opt-in `proxy` config flag (default off) — off means today's behavior, unchanged.
+
+**Tech Stack:** Python 3.11+ asyncio, `bleak==3.0.2` (central, existing), `bless` (peripheral, new), `PyYAML`, pytest.
+
+## Global Constraints
+
+- **Opt-in, default off.** With `proxy.enabled` false/absent, the connector's runtime behavior is byte-for-byte unchanged. No proxy object is constructed.
+- **Single radio (`hci0`).** Concurrent central+peripheral. Dual-adapter is a documented fallback only; do not build it.
+- **No pairing/bonding/encryption.** The VVM link is open GATT; do not add security handshakes.
+- **App selects by name**, advertising `VVM_84FD27D92CBE` (from `ble-device.name`), cloned service UUIDs, our own MAC. No MAC-cloning.
+- **Advertise only while the upstream VVM link is up and streaming.** When upstream drops, stop advertising and drop the app.
+- **SignalK is independent of the app.** The central does its normal bootstrap init so data flows with no app connected.
+- **Custom service base:** `0000XXXX-0000-1000-8000-ec55f9f5b963`. Fault char `0x0201` and control chars `0x0301/0x0302/0x0401/0x2a05` are indicate-type.
+- **Follow existing test style:** pytest, fakes patching `vvm_to_signalk.<module>.<Symbol>` (see `tests/test_blelogic.py`). No network/BLE in unit tests.
+- Spec: `docs/superpowers/specs/2026-07-20-ble-gatt-proxy-design.md`.
+
+## File Structure
+
+- Create `vvm_to_signalk/traffic_capture.py` — `TrafficCapture`: append-only timestamped hex log of relayed ops. No BLE deps.
+- Create `vvm_to_signalk/proxy_config.py` — `ProxyConfig`: parses the `proxy` config section; `.valid`/`.enabled`.
+- Create `vvm_to_signalk/gatt_mirror.py` — `GattProfileMirror`: turns discovered bleak services into a spec of bless services/chars.
+- Create `vvm_to_signalk/proxy_peripheral.py` — `VvmProxyPeripheral`: wraps a `bless` GATT server; advertising, read/write callbacks, notification push.
+- Create `vvm_to_signalk/proxy_relay.py` — `ProxyRelay`: coordinator wiring central ↔ peripheral + advertising lifecycle.
+- Create `tools/proxy_concurrency_spike.py` — standalone hardware go/no-go (advertise while VVM link held).
+- Modify `vvm_to_signalk/ble_connection.py` — notification fan-out hook + `proxy_write`/`proxy_read` on `BleDeviceConnection`; expose discovered services.
+- Modify `vvm_to_signalk/vvm_monitor.py` — `VVMConfig` reads `proxy`; `main()` constructs + runs the relay when enabled.
+- Modify `requirements.txt` — add `bless`.
+- Modify `vvm_monitor.example.yaml` — document the `proxy` section.
+- Tests: `tests/test_traffic_capture.py`, `tests/test_proxy_config.py`, `tests/test_gatt_mirror.py`, `tests/test_ble_proxy_hooks.py`, `tests/test_proxy_relay.py`.
+
+---
+
+### Task 0: Add `bless` dependency + concurrency spike (HARDWARE GATE)
+
+**Files:**
+- Modify: `requirements.txt`
+- Create: `tools/proxy_concurrency_spike.py`
+
+**Interfaces:**
+- Produces: nothing consumed by later tasks; this is the go/no-go that Approach A (single radio) works on the boat.
+
+- [ ] **Step 1: Add the dependency**
+
+Append to `requirements.txt`:
+```
+bless==0.2.6
+```
+
+- [ ] **Step 2: Write the spike tool**
+
+Create `tools/proxy_concurrency_spike.py`:
+```python
+"""Hardware go/no-go for the single-radio BLE proxy (Approach A).
+
+Connects to the VVM as a central AND advertises a dummy peripheral on the same
+adapter at the same time. If both hold for ~60s with no error/disconnect, the Pi
+controller supports the concurrent central+peripheral roles the proxy needs.
+
+Run ON THE BOAT PI:
+    python -m tools.proxy_concurrency_spike --address 84:FD:27:D9:2C:BE
+"""
+import argparse
+import asyncio
+import logging
+
+from bleak import BleakClient
+from bless import BlessServer, GATTCharacteristicProperties, GATTAttributePermissions
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("spike")
+
+DUMMY_SERVICE = "0000fff0-0000-1000-8000-00805f9b34fb"
+DUMMY_CHAR = "0000fff1-0000-1000-8000-00805f9b34fb"
+
+
+async def main(address: str, name: str, hold: float):
+    server = BlessServer(name=name)
+    await server.add_new_service(DUMMY_SERVICE)
+    await server.add_new_characteristic(
+        DUMMY_SERVICE, DUMMY_CHAR,
+        GATTCharacteristicProperties.read | GATTCharacteristicProperties.notify,
+        bytearray(b"\x00"),
+        GATTAttributePermissions.readable,
+    )
+    async with BleakClient(address, timeout=20.0) as client:
+        log.info("CENTRAL connected to VVM %s", address)
+        await server.start()
+        log.info("PERIPHERAL advertising as %s -- both roles now live", name)
+        log.info("Holding both for %.0fs; watch for disconnects/errors...", hold)
+        await asyncio.sleep(hold)
+        await server.stop()
+        log.info("GO: both roles held for the full window with no error")
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--address", required=True, help="VVM BLE address")
+    p.add_argument("--name", default="VVM_SPIKE_TEST")
+    p.add_argument("--hold", type=float, default=60.0)
+    args = p.parse_args()
+    asyncio.run(main(args.address, args.name, args.hold))
+```
+
+- [ ] **Step 3: Run on the boat (manual hardware gate)**
+
+On the boat Pi (inside a container/venv per the work-in-containers rule, or ad hoc):
+```bash
+python -m tools.proxy_concurrency_spike --address 84:FD:27:D9:2C:BE --hold 60
+```
+Expected: `CENTRAL connected` → `PERIPHERAL advertising` → `GO: both roles held ...`, no disconnect. On a separate phone, confirm `VVM_SPIKE_TEST` appears in a BLE scanner while the central is connected.
+**If this fails** (advertising rejected while connected, or the VVM link drops when advertising starts): STOP and switch to the dual-adapter fallback in the spec before continuing.
+
+- [ ] **Step 4: Commit**
+```bash
+git add requirements.txt tools/proxy_concurrency_spike.py
+git commit -m "proxy: add bless dep + single-radio concurrency spike tool"
+```
+
+---
+
+### Task 1: TrafficCapture
+
+**Files:**
+- Create: `vvm_to_signalk/traffic_capture.py`
+- Test: `tests/test_traffic_capture.py`
+
+**Interfaces:**
+- Produces:
+  - `class TrafficCapture(path: str, enabled: bool = True)`
+  - `.record(direction: str, operation: str, uuid: str, data: bytes, now: datetime | None = None) -> None` — appends one line; `direction ∈ {"app->vvm","vvm->app"}`, `operation ∈ {"write","notify","read","subscribe"}`.
+  - `.close() -> None`
+  - Line format: `<iso8601> <direction> <operation> <uuid> <hex>\n` (hex empty string when `data` is empty).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_traffic_capture.py`:
+```python
+from datetime import datetime, timezone
+from vvm_to_signalk.traffic_capture import TrafficCapture
+
+
+def test_record_writes_one_line(tmp_path):
+    path = tmp_path / "capture.log"
+    cap = TrafficCapture(str(path))
+    ts = datetime(2026, 7, 20, 1, 2, 3, tzinfo=timezone.utc)
+    cap.record("app->vvm", "write", "00000001-0000-1000-8000-ec55f9f5b963",
+               bytes.fromhex("a1b2"), now=ts)
+    cap.close()
+    line = path.read_text().strip()
+    assert line == ("2026-07-20T01:02:03+00:00 app->vvm write "
+                    "00000001-0000-1000-8000-ec55f9f5b963 a1b2")
+
+
+def test_disabled_capture_writes_nothing(tmp_path):
+    path = tmp_path / "capture.log"
+    cap = TrafficCapture(str(path), enabled=False)
+    cap.record("vvm->app", "notify", "x", b"\x01", now=datetime.now(timezone.utc))
+    cap.close()
+    assert not path.exists()
+
+
+def test_empty_data_has_empty_hex(tmp_path):
+    path = tmp_path / "capture.log"
+    cap = TrafficCapture(str(path))
+    ts = datetime(2026, 7, 20, 0, 0, 0, tzinfo=timezone.utc)
+    cap.record("app->vvm", "subscribe", "uuid", b"", now=ts)
+    cap.close()
+    assert path.read_text().strip().endswith("subscribe uuid ")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_traffic_capture.py -v`
+Expected: FAIL with `ModuleNotFoundError: vvm_to_signalk.traffic_capture`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `vvm_to_signalk/traffic_capture.py`:
+```python
+"""Append-only capture of relayed BLE proxy traffic."""
+import logging
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+
+class TrafficCapture:
+    """Records every relayed GATT operation as one timestamped hex line."""
+
+    def __init__(self, path: str, enabled: bool = True):
+        self._enabled = enabled
+        self._path = path
+        self._fh = None
+        if self._enabled:
+            self._fh = open(path, "a", encoding="utf-8")  # noqa: SIM115
+
+    def record(self, direction: str, operation: str, uuid: str, data: bytes,
+               now: datetime | None = None) -> None:
+        """Append one capture line. No-op when disabled."""
+        if not self._enabled or self._fh is None:
+            return
+        ts = (now or datetime.now(timezone.utc)).isoformat()
+        self._fh.write(f"{ts} {direction} {operation} {uuid} {data.hex()}\n")
+        self._fh.flush()
+
+    def close(self) -> None:
+        """Close the capture file."""
+        if self._fh is not None:
+            self._fh.close()
+            self._fh = None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_traffic_capture.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+```bash
+git add vvm_to_signalk/traffic_capture.py tests/test_traffic_capture.py
+git commit -m "proxy: TrafficCapture append-only relayed-traffic log"
+```
+
+---
+
+### Task 2: ProxyConfig
+
+**Files:**
+- Create: `vvm_to_signalk/proxy_config.py`
+- Test: `tests/test_proxy_config.py`
+
+**Interfaces:**
+- Produces:
+  - `class ProxyConfig(data: dict | None = None)`
+  - Properties: `.enabled: bool` (default False), `.capture_file: str` (default `./logs/ble_capture.log`), `.advertised_name: str | None` (default None → relay uses the ble-device name).
+  - `.read(data: dict | None) -> None`
+  - `.valid: bool` → True only when `.enabled` is True.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_proxy_config.py`:
+```python
+from vvm_to_signalk.proxy_config import ProxyConfig
+
+
+def test_default_disabled_and_invalid():
+    c = ProxyConfig()
+    assert c.enabled is False
+    assert c.valid is False
+    assert c.capture_file == "./logs/ble_capture.log"
+    assert c.advertised_name is None
+
+
+def test_read_enables_and_overrides():
+    c = ProxyConfig({"enabled": True, "capture-file": "/x/cap.log",
+                     "advertised-name": "VVM_TEST"})
+    assert c.enabled is True
+    assert c.valid is True
+    assert c.capture_file == "/x/cap.log"
+    assert c.advertised_name == "VVM_TEST"
+
+
+def test_read_none_is_noop():
+    c = ProxyConfig()
+    c.read(None)
+    assert c.enabled is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_proxy_config.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `vvm_to_signalk/proxy_config.py`:
+```python
+"""Configuration for the BLE GATT proxy mode."""
+
+
+class ProxyConfig:
+    """Parses the optional `proxy` config section. Disabled by default."""
+
+    def __init__(self, data: dict | None = None):
+        self._enabled = False
+        self._capture_file = "./logs/ble_capture.log"
+        self._advertised_name = None
+        if data is not None:
+            self.read(data)
+
+    def read(self, data: dict | None) -> None:
+        """Read proxy settings from a dict; None is a no-op."""
+        if data is None:
+            return
+        self._enabled = bool(data.get("enabled", self._enabled))
+        self._capture_file = data.get("capture-file", self._capture_file)
+        self._advertised_name = data.get("advertised-name", self._advertised_name)
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def capture_file(self) -> str:
+        return self._capture_file
+
+    @property
+    def advertised_name(self):
+        return self._advertised_name
+
+    @property
+    def valid(self) -> bool:
+        """The proxy is only 'valid' (should be constructed) when enabled."""
+        return self._enabled
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_proxy_config.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+```bash
+git add vvm_to_signalk/proxy_config.py tests/test_proxy_config.py
+git commit -m "proxy: ProxyConfig (opt-in, default off)"
+```
+
+---
+
+### Task 3: GattProfileMirror
+
+**Files:**
+- Create: `vvm_to_signalk/gatt_mirror.py`
+- Test: `tests/test_gatt_mirror.py`
+
+**Interfaces:**
+- Consumes: bleak's discovered `client.services` (a `BleakGATTServiceCollection`: iterable of services, each `.uuid` + `.characteristics`; each characteristic `.uuid` + `.properties` list of strings like `"read"`, `"write"`, `"notify"`, `"indicate"`, `"write-without-response"`).
+- Produces:
+  - `def mirror_profile(services) -> list[MirroredService]`
+  - `@dataclass MirroredService: uuid: str; characteristics: list[MirroredChar]`
+  - `@dataclass MirroredChar: uuid: str; properties: int; permissions: int` where `properties` is an OR of `bless.GATTCharacteristicProperties` flags and `permissions` an OR of `bless.GATTAttributePermissions`.
+  - Mapping: bleak prop string → bless flag: `read→read, write→write, write-without-response→write_without_response, notify→notify, indicate→indicate`. Any `read` in props ⇒ `permissions |= readable`; any `write`/`write-without-response` ⇒ `permissions |= writeable`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_gatt_mirror.py`:
+```python
+from bless import GATTCharacteristicProperties as P, GATTAttributePermissions as Perm
+from vvm_to_signalk.gatt_mirror import mirror_profile
+
+
+class _FakeChar:
+    def __init__(self, uuid, properties):
+        self.uuid = uuid
+        self.properties = properties
+
+
+class _FakeService:
+    def __init__(self, uuid, chars):
+        self.uuid = uuid
+        self.characteristics = chars
+
+
+def test_mirror_maps_props_and_permissions():
+    services = [_FakeService("svc-1", [
+        _FakeChar("char-notify", ["notify"]),
+        _FakeChar("char-rw", ["read", "write"]),
+        _FakeChar("char-indicate", ["indicate"]),
+    ])]
+    mirrored = mirror_profile(services)
+    assert len(mirrored) == 1
+    svc = mirrored[0]
+    assert svc.uuid == "svc-1"
+    by_uuid = {c.uuid: c for c in svc.characteristics}
+
+    assert by_uuid["char-notify"].properties & P.notify
+    assert by_uuid["char-indicate"].properties & P.indicate
+    rw = by_uuid["char-rw"]
+    assert rw.properties & P.read
+    assert rw.properties & P.write
+    assert rw.permissions & Perm.readable
+    assert rw.permissions & Perm.writeable
+    # notify-only char is not writeable
+    assert not (by_uuid["char-notify"].permissions & Perm.writeable)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_gatt_mirror.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `vvm_to_signalk/gatt_mirror.py`:
+```python
+"""Mirror a discovered VVM GATT profile into bless service/characteristic specs."""
+from dataclasses import dataclass
+
+from bless import GATTCharacteristicProperties as P, GATTAttributePermissions as Perm
+
+_PROP_MAP = {
+    "read": P.read,
+    "write": P.write,
+    "write-without-response": P.write_without_response,
+    "notify": P.notify,
+    "indicate": P.indicate,
+}
+
+
+@dataclass
+class MirroredChar:
+    uuid: str
+    properties: int
+    permissions: int
+
+
+@dataclass
+class MirroredService:
+    uuid: str
+    characteristics: list
+
+
+def mirror_profile(services) -> list:
+    """Convert bleak-discovered services into a list of MirroredService."""
+    result = []
+    for service in services:
+        chars = []
+        for characteristic in service.characteristics:
+            props = 0
+            perms = 0
+            for name in characteristic.properties:
+                flag = _PROP_MAP.get(name)
+                if flag is not None:
+                    props |= flag
+                if name == "read":
+                    perms |= Perm.readable
+                if name in ("write", "write-without-response"):
+                    perms |= Perm.writeable
+            chars.append(MirroredChar(characteristic.uuid, props, perms))
+        result.append(MirroredService(service.uuid, chars))
+    return result
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_gatt_mirror.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+```bash
+git add vvm_to_signalk/gatt_mirror.py tests/test_gatt_mirror.py
+git commit -m "proxy: GattProfileMirror clones discovered GATT into bless specs"
+```
+
+---
+
+### Task 4: BleDeviceConnection proxy hooks
+
+**Files:**
+- Modify: `vvm_to_signalk/ble_connection.py`
+- Test: `tests/test_ble_proxy_hooks.py`
+
+**Interfaces:**
+- Consumes: existing `BleDeviceConnection`, `notification_handler(characteristic, data)`.
+- Produces on `BleDeviceConnection`:
+  - `set_notification_observer(cb: Callable[[str, bytes], None] | None) -> None` — registers a callback invoked with `(uuid, data)` for every notification, *in addition to* normal SignalK decoding. Set to `None` to clear.
+  - `async proxy_write(uuid: str, data: bytes, response: bool = True) -> None` — writes to the connected VVM on the app's behalf; no-op (logged) if not connected.
+  - `async proxy_read(uuid: str) -> bytes` — reads from the connected VVM; raises `RuntimeError("not connected")` if no client.
+  - The connection stores the active `client` in `self._active_client` (None when disconnected) so the relay can drive writes/reads.
+  - Fan-out is invoked at the *top* of `notification_handler` (before the early returns), so the observer sees fault/config/channel notifications alike.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_ble_proxy_hooks.py`:
+```python
+import asyncio
+from unittest.mock import AsyncMock
+
+from vvm_to_signalk.ble_connection import BleDeviceConnection, BleConnectionConfig
+
+
+class _FakeChar:
+    def __init__(self, uuid):
+        self.uuid = uuid
+
+
+def _make_conn():
+    cfg = BleConnectionConfig({"address": "AA:BB:CC:DD:EE:FF"})
+    return BleDeviceConnection(cfg, {})
+
+
+def test_observer_sees_every_notification():
+    conn = _make_conn()
+    seen = []
+    conn.set_notification_observer(lambda uuid, data: seen.append((uuid, bytes(data))))
+    # A channel notification (unknown item -> decode path) still reaches the observer.
+    conn.notification_handler(_FakeChar("00000201-0000-1000-8000-ec55f9f5b963"),
+                              bytearray(b"\x01\x02\x03"))
+    assert seen == [("00000201-0000-1000-8000-ec55f9f5b963", b"\x01\x02\x03")]
+
+
+def test_observer_cleared():
+    conn = _make_conn()
+    seen = []
+    conn.set_notification_observer(lambda uuid, data: seen.append(uuid))
+    conn.set_notification_observer(None)
+    conn.notification_handler(_FakeChar("uuid"), bytearray(b"\x00"))
+    assert seen == []
+
+
+def test_proxy_write_uses_active_client():
+    conn = _make_conn()
+    client = AsyncMock()
+    conn._active_client = client
+    asyncio.run(conn.proxy_write("uuid-x", b"\xaa", response=True))
+    client.write_gatt_char.assert_awaited_once_with("uuid-x", b"\xaa", response=True)
+
+
+def test_proxy_read_without_client_raises():
+    conn = _make_conn()
+    conn._active_client = None
+    try:
+        asyncio.run(conn.proxy_read("uuid-x"))
+        assert False, "expected RuntimeError"
+    except RuntimeError:
+        pass
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_ble_proxy_hooks.py -v`
+Expected: FAIL (`AttributeError: set_notification_observer`).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `vvm_to_signalk/ble_connection.py`, in `BleDeviceConnection.__init__` add near the other instance attrs:
+```python
+        self._active_client = None          # set while a BLE client is connected
+        self._notification_observer = None  # proxy fan-out callback (uuid, data)
+```
+
+Add these methods to `BleDeviceConnection` (place them just after `accept_data_receiver`):
+```python
+    def set_notification_observer(self, callback) -> None:
+        """Register a callback(uuid: str, data: bytes) invoked for every
+        notification, in addition to normal decoding. None clears it.
+        Used by the BLE proxy to forward the VVM stream to the native app."""
+        self._notification_observer = callback
+
+    async def proxy_write(self, uuid: str, data: bytes, response: bool = True) -> None:
+        """Write to the connected VVM on the app's behalf (proxy mode)."""
+        client = self._active_client
+        if client is None:
+            logger.warning("proxy_write dropped (no active VVM connection): %s", uuid)
+            return
+        await client.write_gatt_char(uuid, data, response=response)
+
+    async def proxy_read(self, uuid: str) -> bytes:
+        """Read a characteristic from the connected VVM (proxy mode)."""
+        client = self._active_client
+        if client is None:
+            raise RuntimeError("not connected")
+        return bytes(await client.read_gatt_char(uuid))
+```
+
+At the very top of `notification_handler`, before the `__last_message_time` line stays first, add the fan-out immediately after it:
+```python
+    def notification_handler(self, characteristic: BleakGATTCharacteristic, data: bytearray):
+        """Handles BLE notifications and indications."""
+        self.__last_message_time = asyncio.get_event_loop().time()
+        observer = self._notification_observer
+        if observer is not None:
+            try:
+                observer(characteristic.uuid, bytes(data))
+            except Exception as e:  # never let the proxy break decoding
+                logger.warning("notification observer error: %s", e)
+        uuid = characteristic.uuid
+        # ... existing body unchanged ...
+```
+
+In `_device_init_and_loop`, right after `connected = True` (line ~136), record the active client so the relay can drive it; and clear it in the `finally` block:
+```python
+                self._set_health(True, "Connected to device")
+                connected = True
+                self._active_client = client
+                self._reset_unparsed_tracking()
+```
+and in the `finally:` of `_device_init_and_loop` add:
+```python
+        finally:
+            self._active_client = None
+            self._finalize_fault_subscribe_state()
+            # ... existing finally body ...
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_ble_proxy_hooks.py tests/test_blelogic.py -v`
+Expected: new file PASS; `test_blelogic.py` still all PASS (no regression).
+
+- [ ] **Step 5: Commit**
+```bash
+git add vvm_to_signalk/ble_connection.py tests/test_ble_proxy_hooks.py
+git commit -m "proxy: notification fan-out + proxy_write/proxy_read hooks on central"
+```
+
+---
+
+### Task 5: VvmProxyPeripheral
+
+**Files:**
+- Create: `vvm_to_signalk/proxy_peripheral.py`
+- Test: `tests/test_proxy_peripheral.py`
+
+**Interfaces:**
+- Consumes: `MirroredService`/`MirroredChar` from `gatt_mirror`; a `bless.BlessServer` (constructed via an injectable factory for testing).
+- Produces:
+  - `class VvmProxyPeripheral(name: str, mirrored: list[MirroredService], on_write, on_read, server_factory=BlessServer)`
+    - `on_write(uuid: str, data: bytes) -> None` — called when the app writes a char (relay forwards to VVM).
+    - `on_read(uuid: str) -> bytes` — called when the app reads a char (relay returns cached/live VVM value).
+  - `async start() -> None` — builds services/chars on the server, wires read/write callbacks, calls `server.start()` (begins advertising).
+  - `async stop() -> None` — `server.stop()` (stops advertising / disconnects app).
+  - `async push_notification(uuid: str, data: bytes) -> None` — sets the char value and calls `server.update_value(service_uuid, uuid)` so subscribed apps get the notification. Silently ignores unknown UUIDs.
+  - Internally maps each char uuid → its service uuid for `update_value`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_proxy_peripheral.py`:
+```python
+import asyncio
+
+from vvm_to_signalk.gatt_mirror import MirroredService, MirroredChar
+from vvm_to_signalk.proxy_peripheral import VvmProxyPeripheral
+
+
+class _FakeServer:
+    def __init__(self, name, **kw):
+        self.name = name
+        self.services_added = []
+        self.chars_added = []
+        self.started = False
+        self.stopped = False
+        self.updated = []
+        self.read_request_func = None
+        self.write_request_func = None
+        self._values = {}
+
+    async def add_new_service(self, uuid):
+        self.services_added.append(uuid)
+
+    async def add_new_characteristic(self, svc, uuid, props, value, perms):
+        self.chars_added.append((svc, uuid))
+        self._values[uuid] = bytearray(value or b"")
+
+    def get_characteristic(self, uuid):
+        class _C:
+            pass
+        c = _C()
+        c.value = self._values.get(uuid, bytearray())
+        c.uuid = uuid
+        self._values[uuid] = c.value
+        return c
+
+    async def start(self):
+        self.started = True
+
+    async def stop(self):
+        self.stopped = True
+
+    def update_value(self, svc, uuid):
+        self.updated.append((svc, uuid))
+        return True
+
+
+def _peripheral(writes, reads):
+    mirrored = [MirroredService("svc-1", [
+        MirroredChar("char-a", 0x10, 0x01),
+        MirroredChar("char-b", 0x08, 0x02),
+    ])]
+    servers = {}
+
+    def factory(name, **kw):
+        s = _FakeServer(name, **kw)
+        servers["s"] = s
+        return s
+
+    p = VvmProxyPeripheral(
+        "VVM_TEST", mirrored,
+        on_write=lambda uuid, data: writes.append((uuid, bytes(data))),
+        on_read=lambda uuid: reads.get(uuid, b""),
+        server_factory=factory,
+    )
+    return p, servers
+
+
+def test_start_builds_profile_and_advertises():
+    p, servers = _peripheral([], {})
+    asyncio.run(p.start())
+    s = servers["s"]
+    assert s.services_added == ["svc-1"]
+    assert set(u for _, u in s.chars_added) == {"char-a", "char-b"}
+    assert s.started is True
+
+
+def test_push_notification_updates_value():
+    p, servers = _peripheral([], {})
+    asyncio.run(p.start())
+    asyncio.run(p.push_notification("char-a", b"\x99"))
+    s = servers["s"]
+    assert ("svc-1", "char-a") in s.updated
+
+
+def test_push_unknown_uuid_is_ignored():
+    p, servers = _peripheral([], {})
+    asyncio.run(p.start())
+    asyncio.run(p.push_notification("nope", b"\x01"))  # must not raise
+    assert ("svc-1", "nope") not in servers["s"].updated
+
+
+def test_write_callback_invoked():
+    writes = []
+    p, servers = _peripheral(writes, {})
+    asyncio.run(p.start())
+    s = servers["s"]
+    # simulate bless invoking the registered write handler
+
+    class _C:
+        uuid = "char-b"
+    s.write_request_func(_C(), bytearray(b"\x42"))
+    assert writes == [("char-b", b"\x42")]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_proxy_peripheral.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `vvm_to_signalk/proxy_peripheral.py`:
+```python
+"""bless GATT-server peripheral that emulates the VVM to the native app."""
+import logging
+
+from bless import BlessServer
+
+logger = logging.getLogger(__name__)
+
+
+class VvmProxyPeripheral:
+    """Advertises a cloned VVM profile and relays app<->VVM via callbacks."""
+
+    def __init__(self, name, mirrored, on_write, on_read, server_factory=BlessServer):
+        self._name = name
+        self._mirrored = mirrored
+        self._on_write = on_write
+        self._on_read = on_read
+        self._server_factory = server_factory
+        self._server = None
+        self._char_to_service = {}
+
+    async def start(self) -> None:
+        """Build the cloned profile and begin advertising."""
+        server = self._server_factory(name=self._name)
+        server.read_request_func = self._handle_read
+        server.write_request_func = self._handle_write
+        for service in self._mirrored:
+            await server.add_new_service(service.uuid)
+            for char in service.characteristics:
+                self._char_to_service[char.uuid] = service.uuid
+                await server.add_new_characteristic(
+                    service.uuid, char.uuid, char.properties,
+                    bytearray(), char.permissions)
+        await server.start()
+        self._server = server
+        logger.info("Proxy peripheral advertising as %s (%d chars)",
+                    self._name, len(self._char_to_service))
+
+    async def stop(self) -> None:
+        """Stop advertising and disconnect the app."""
+        if self._server is not None:
+            await self._server.stop()
+            self._server = None
+
+    async def push_notification(self, uuid: str, data: bytes) -> None:
+        """Deliver a VVM notification to a subscribed app."""
+        if self._server is None:
+            return
+        service_uuid = self._char_to_service.get(uuid)
+        if service_uuid is None:
+            return
+        char = self._server.get_characteristic(uuid)
+        if char is None:
+            return
+        char.value = bytearray(data)
+        self._server.update_value(service_uuid, uuid)
+
+    def _handle_read(self, characteristic, **kwargs):
+        """bless read callback: return the current value for the app."""
+        try:
+            return bytearray(self._on_read(characteristic.uuid))
+        except Exception as e:
+            logger.warning("proxy read error on %s: %s", characteristic.uuid, e)
+            return bytearray()
+
+    def _handle_write(self, characteristic, value, **kwargs):
+        """bless write callback: forward the app's write to the VVM."""
+        try:
+            self._on_write(characteristic.uuid, bytes(value))
+        except Exception as e:
+            logger.warning("proxy write error on %s: %s", characteristic.uuid, e)
+```
+
+Note: bless calls `write_request_func(characteristic, value)`; the fake in the test calls it the same way. `read_request_func(characteristic)` returns the value.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_proxy_peripheral.py -v`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Commit**
+```bash
+git add vvm_to_signalk/proxy_peripheral.py tests/test_proxy_peripheral.py
+git commit -m "proxy: VvmProxyPeripheral bless GATT server with relay callbacks"
+```
+
+---
+
+### Task 6: ProxyRelay (coordinator + advertising lifecycle)
+
+**Files:**
+- Create: `vvm_to_signalk/proxy_relay.py`
+- Test: `tests/test_proxy_relay.py`
+
+**Interfaces:**
+- Consumes: `BleDeviceConnection` (`set_notification_observer`, `proxy_write`, `proxy_read`, `_active_client`), `mirror_profile`, `VvmProxyPeripheral`, `TrafficCapture`.
+- Produces:
+  - `class ProxyRelay(connection, proxy_config, advertised_name, loop, peripheral_factory=..., capture=None)`
+  - `async on_upstream_ready(services) -> None` — mirror the profile, build+start the peripheral, register the notification observer. Called by the relay when the VVM link is up and streaming.
+  - `async on_upstream_lost() -> None` — stop the peripheral, clear the observer.
+  - `_forward_notification(uuid, data)` — observer body: capture + schedule `peripheral.push_notification` on the loop.
+  - `_forward_write(uuid, data)` — peripheral on_write body: capture + schedule `connection.proxy_write` on the loop.
+  - `_serve_read(uuid) -> bytes` — peripheral on_read body: returns last-cached notification value for `uuid` (dict updated by `_forward_notification`), else `b""`.
+- The relay caches last-notified values per uuid for reads. Uses `asyncio.run_coroutine_threadsafe`/`loop.create_task` to bridge bless's callbacks to the async central.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_proxy_relay.py`:
+```python
+import asyncio
+
+from vvm_to_signalk.proxy_config import ProxyConfig
+from vvm_to_signalk.proxy_relay import ProxyRelay
+
+
+class _FakeConn:
+    def __init__(self):
+        self.observer = None
+        self.writes = []
+    def set_notification_observer(self, cb):
+        self.observer = cb
+    async def proxy_write(self, uuid, data, response=True):
+        self.writes.append((uuid, bytes(data)))
+
+
+class _FakePeripheral:
+    def __init__(self, name, mirrored, on_write, on_read, **kw):
+        self.name = name
+        self.on_write = on_write
+        self.on_read = on_read
+        self.started = False
+        self.stopped = False
+        self.pushed = []
+    async def start(self):
+        self.started = True
+    async def stop(self):
+        self.stopped = True
+    async def push_notification(self, uuid, data):
+        self.pushed.append((uuid, bytes(data)))
+
+
+class _FakeChar:
+    def __init__(self, uuid, props):
+        self.uuid = uuid
+        self.properties = props
+
+
+class _FakeService:
+    def __init__(self, uuid, chars):
+        self.uuid = uuid
+        self.characteristics = chars
+
+
+def _relay():
+    conn = _FakeConn()
+    made = {}
+    def pf(name, mirrored, on_write, on_read, **kw):
+        p = _FakePeripheral(name, mirrored, on_write, on_read, **kw)
+        made["p"] = p
+        return p
+    relay = ProxyRelay(conn, ProxyConfig({"enabled": True}), "VVM_TEST",
+                       asyncio.get_event_loop(), peripheral_factory=pf)
+    return relay, conn, made
+
+
+def test_ready_starts_peripheral_and_registers_observer():
+    async def run():
+        relay, conn, made = _relay()
+        services = [_FakeService("svc", [_FakeChar("c1", ["notify"])])]
+        await relay.on_upstream_ready(services)
+        assert made["p"].started is True
+        assert conn.observer is not None
+    asyncio.run(run())
+
+
+def test_notification_is_cached_and_forwarded():
+    async def run():
+        relay, conn, made = _relay()
+        services = [_FakeService("svc", [_FakeChar("c1", ["notify"])])]
+        await relay.on_upstream_ready(services)
+        conn.observer("c1", b"\x07")           # simulate a VVM notification
+        await asyncio.sleep(0)                  # let scheduled task run
+        assert ("c1", b"\x07") in made["p"].pushed
+        assert relay._serve_read("c1") == b"\x07"   # cached for reads
+    asyncio.run(run())
+
+
+def test_app_write_forwarded_to_vvm():
+    async def run():
+        relay, conn, made = _relay()
+        services = [_FakeService("svc", [_FakeChar("c1", ["write"])])]
+        await relay.on_upstream_ready(services)
+        made["p"].on_write("c1", b"\x42")       # simulate app write
+        await asyncio.sleep(0)
+        assert ("c1", b"\x42") in conn.writes
+    asyncio.run(run())
+
+
+def test_lost_stops_peripheral_and_clears_observer():
+    async def run():
+        relay, conn, made = _relay()
+        services = [_FakeService("svc", [_FakeChar("c1", ["notify"])])]
+        await relay.on_upstream_ready(services)
+        await relay.on_upstream_lost()
+        assert made["p"].stopped is True
+        assert conn.observer is None
+    asyncio.run(run())
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/test_proxy_relay.py -v`
+Expected: FAIL with `ModuleNotFoundError`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `vvm_to_signalk/proxy_relay.py`:
+```python
+"""Coordinator wiring the VVM central to the app-facing peripheral."""
+import asyncio
+import logging
+
+from .gatt_mirror import mirror_profile
+from .proxy_peripheral import VvmProxyPeripheral
+
+logger = logging.getLogger(__name__)
+
+
+class ProxyRelay:
+    """Relays notifications VVM->app and writes/reads app->VVM."""
+
+    def __init__(self, connection, proxy_config, advertised_name, loop,
+                 peripheral_factory=VvmProxyPeripheral, capture=None):
+        self._conn = connection
+        self._config = proxy_config
+        self._name = advertised_name
+        self._loop = loop
+        self._peripheral_factory = peripheral_factory
+        self._capture = capture
+        self._peripheral = None
+        self._read_cache = {}
+
+    async def on_upstream_ready(self, services) -> None:
+        """VVM link is up: clone the profile, advertise, start relaying."""
+        mirrored = mirror_profile(services)
+        self._peripheral = self._peripheral_factory(
+            self._name, mirrored,
+            on_write=self._forward_write,
+            on_read=self._serve_read)
+        await self._peripheral.start()
+        self._conn.set_notification_observer(self._forward_notification)
+        logger.info("Proxy relay active (advertising %s)", self._name)
+
+    async def on_upstream_lost(self) -> None:
+        """VVM link dropped: stop advertising and clear the relay."""
+        self._conn.set_notification_observer(None)
+        if self._peripheral is not None:
+            await self._peripheral.stop()
+            self._peripheral = None
+        self._read_cache.clear()
+        logger.info("Proxy relay stopped (upstream lost)")
+
+    def _forward_notification(self, uuid, data):
+        """Observer body (called from the central's notification path)."""
+        self._read_cache[uuid] = bytes(data)
+        if self._capture is not None:
+            self._capture.record("vvm->app", "notify", uuid, bytes(data))
+        peripheral = self._peripheral
+        if peripheral is not None:
+            self._loop.create_task(peripheral.push_notification(uuid, bytes(data)))
+
+    def _forward_write(self, uuid, data):
+        """Peripheral on_write body (called from bless callback thread/loop)."""
+        if self._capture is not None:
+            self._capture.record("app->vvm", "write", uuid, bytes(data))
+        asyncio.run_coroutine_threadsafe(
+            self._conn.proxy_write(uuid, bytes(data)), self._loop)
+
+    def _serve_read(self, uuid) -> bytes:
+        """Peripheral on_read body: last-known value for the char."""
+        value = self._read_cache.get(uuid, b"")
+        if self._capture is not None:
+            self._capture.record("app->vvm", "read", uuid, value)
+        return value
+```
+
+Note on the test: `test_app_write_forwarded_to_vvm` uses `run_coroutine_threadsafe` against the running loop; in the test the loop is running under `asyncio.run`, so the future is scheduled and executed on the next `await asyncio.sleep(0)`. If flaky under the test runner, the implementer may special-case "current loop" with `create_task`; keep the threadsafe path for the real bless callback which fires off-loop.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/test_proxy_relay.py -v`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Commit**
+```bash
+git add vvm_to_signalk/proxy_relay.py tests/test_proxy_relay.py
+git commit -m "proxy: ProxyRelay coordinator + read cache + capture wiring"
+```
+
+---
+
+### Task 7: Wire proxy into config + main; advertising lifecycle from the central
+
+**Files:**
+- Modify: `vvm_to_signalk/vvm_monitor.py` (`VVMConfig.read`, add `proxy` property, `main()`)
+- Modify: `vvm_to_signalk/ble_connection.py` (invoke relay `on_upstream_ready`/`on_upstream_lost`)
+- Modify: `vvm_monitor.example.yaml`
+- Test: `tests/test_vvm_monitor.py` (extend), `tests/test_blelogic.py` (no regression)
+
+**Interfaces:**
+- Consumes: `ProxyConfig`, `ProxyRelay`, `TrafficCapture`, `BleDeviceConnection`.
+- Produces:
+  - `VVMConfig.proxy -> ProxyConfig`; `VVMConfig.read` parses `data.get('proxy')`.
+  - `BleDeviceConnection.set_proxy_relay(relay) -> None` — the connection calls `await relay.on_upstream_ready(client.services)` right after streaming is enabled + fault subscribe (end of the connect setup, line ~162), and `await relay.on_upstream_lost()` in the `finally`.
+  - `main()`: when `config.proxy.valid`, build `TrafficCapture(config.proxy.capture_file)`, build `ProxyRelay(self.__ble_connection, config.proxy, name, loop, capture=capture)`, and `self.__ble_connection.set_proxy_relay(relay)`. `name` = `config.proxy.advertised_name or config.bluetooth.device_name`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `tests/test_vvm_monitor.py`:
+```python
+def test_vvmconfig_reads_proxy_section():
+    from vvm_to_signalk.vvm_monitor import VVMConfig
+    cfg = VVMConfig({"proxy": {"enabled": True, "advertised-name": "VVM_X"}})
+    assert cfg.proxy.enabled is True
+    assert cfg.proxy.advertised_name == "VVM_X"
+
+
+def test_vvmconfig_proxy_default_off():
+    from vvm_to_signalk.vvm_monitor import VVMConfig
+    cfg = VVMConfig({})
+    assert cfg.proxy.enabled is False
+```
+
+Add to `tests/test_ble_proxy_hooks.py`:
+```python
+def test_set_proxy_relay_ready_and_lost_called():
+    import asyncio
+    conn = _make_conn()
+
+    class _Relay:
+        def __init__(self):
+            self.ready = None
+            self.lost = False
+        async def on_upstream_ready(self, services):
+            self.ready = services
+        async def on_upstream_lost(self):
+            self.lost = True
+
+    relay = _Relay()
+    conn.set_proxy_relay(relay)
+    # the connection exposes helpers the loop calls; test them directly
+    asyncio.run(conn._proxy_notify_ready(["svc"]))
+    assert relay.ready == ["svc"]
+    asyncio.run(conn._proxy_notify_lost())
+    assert relay.lost is True
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest tests/test_vvm_monitor.py::test_vvmconfig_reads_proxy_section tests/test_ble_proxy_hooks.py::test_set_proxy_relay_ready_and_lost_called -v`
+Expected: FAIL (`proxy` attr / `set_proxy_relay` missing).
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `vvm_to_signalk/vvm_monitor.py`:
+- import: `from .proxy_config import ProxyConfig` and `from .proxy_relay import ProxyRelay` and `from .traffic_capture import TrafficCapture`.
+- In `VVMConfig.__init__`: `self._proxy_config = ProxyConfig()`.
+- In `VVMConfig.read`: add `self.proxy.read(data.get('proxy'))`.
+- Add property:
+```python
+    @property
+    def proxy(self):
+        """Configuration for the BLE GATT proxy mode."""
+        return self._proxy_config
+```
+- In `main()`, after the `self.__ble_connection` is created and receivers attached, before the TaskGroup:
+```python
+        if self.__ble_connection is not None and config.proxy.valid:
+            loop = asyncio.get_event_loop()
+            capture = TrafficCapture(config.proxy.capture_file)
+            adv_name = config.proxy.advertised_name or config.bluetooth.device_name
+            relay = ProxyRelay(self.__ble_connection, config.proxy, adv_name,
+                               loop, capture=capture)
+            self.__ble_connection.set_proxy_relay(relay)
+            logger.info("BLE GATT proxy enabled (advertising as %s)", adv_name)
+```
+
+In `vvm_to_signalk/ble_connection.py`:
+- In `__init__`: `self._proxy_relay = None`.
+- Add methods:
+```python
+    def set_proxy_relay(self, relay) -> None:
+        """Attach a ProxyRelay to mirror the VVM link to the native app."""
+        self._proxy_relay = relay
+
+    async def _proxy_notify_ready(self, services) -> None:
+        if self._proxy_relay is not None:
+            try:
+                await self._proxy_relay.on_upstream_ready(services)
+            except Exception as e:
+                logger.warning("Proxy start failed (continuing without it): %s", e)
+
+    async def _proxy_notify_lost(self) -> None:
+        if self._proxy_relay is not None:
+            try:
+                await self._proxy_relay.on_upstream_lost()
+            except Exception as e:
+                logger.warning("Proxy stop error: %s", e)
+```
+- In `_device_init_and_loop`, right after `await self._subscribe_fault_alert(client)` (line ~162):
+```python
+                await self._subscribe_fault_alert(client)
+                await self._proxy_notify_ready(client.services)
+```
+- In the `finally:` of `_device_init_and_loop`, before clearing `_active_client`:
+```python
+        finally:
+            await self._proxy_notify_lost()
+            self._active_client = None
+            self._finalize_fault_subscribe_state()
+            # ... existing finally body ...
+```
+(Note: the `finally` is now `async`-safe because `_device_init_and_loop` is already a coroutine.)
+
+In `vvm_monitor.example.yaml`, add:
+```yaml
+# Optional: BLE GATT proxy so the native SmartCraft app can connect through
+# this connector to the engine (the VVM only allows one BLE connection).
+# Default: disabled. Requires an adapter that supports concurrent
+# central+peripheral roles on one radio.
+proxy:
+  enabled: false
+  # File that captures all relayed BLE traffic (timestamped hex).
+  capture-file: ./logs/ble_capture.log
+  # Name to advertise to the app. Defaults to ble-device.name when omitted.
+  # advertised-name: "VVM_84FD27D92CBE"
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest tests/test_vvm_monitor.py tests/test_ble_proxy_hooks.py tests/test_blelogic.py -v`
+Expected: all PASS (no regression in `test_blelogic.py`).
+
+- [ ] **Step 5: Full suite + commit**
+
+Run: `pytest -q`
+Expected: all pass.
+```bash
+git add vvm_to_signalk/vvm_monitor.py vvm_to_signalk/ble_connection.py vvm_monitor.example.yaml tests/test_vvm_monitor.py tests/test_ble_proxy_hooks.py
+git commit -m "proxy: wire ProxyRelay into config + connect/disconnect lifecycle"
+```
+
+---
+
+### Task 8: End-to-end hardware validation (HARDWARE GATE)
+
+**Files:** none (deploy + observe). Uses the boat per `boat-pi-deployment` memory.
+
+**Interfaces:** validates the whole feature on real hardware before any release.
+
+- [ ] **Step 1: Build a PR image**
+
+Push the branch and open a PR so CI publishes `rgregg/vvm_monitor:pr-<N>` (multi-arch incl. arm64), per the existing `docker-pr-image.yml`. Do **not** touch `:1`.
+
+- [ ] **Step 2: Deploy to the boat on the pr- image**
+
+On the boat, back up compose, point `image:` at `rgregg/vvm_monitor:pr-<N>`, add a `proxy:` block with `enabled: true` to `config/vvm_monitor.yaml`, then:
+```bash
+docker compose pull vvm && docker compose up -d vvm
+docker logs -f vvm_monitor
+```
+Expected log lines: `BLE GATT proxy enabled (advertising as VVM_...)`, then on connect `Proxy relay active (advertising VVM_...)`.
+
+- [ ] **Step 3: End-to-end check (engine on)**
+
+With the engine/VVM powered:
+1. Confirm SignalK still updates: `curl -s http://localhost:3000/signalk/v1/api/vessels/self/propulsion | head`.
+2. On the phone, open the native SmartCraft app; confirm `VVM_...` appears and connects **through the proxy**, and shows live engine data.
+3. Confirm `logs/ble_capture.log` is populating with `app->vvm` and `vvm->app` lines.
+
+- [ ] **Step 4: Indicate-subscribe check**
+
+Watch for an upstream drop right after the app subscribes. In `ble_capture.log`, find the app's CCCD writes to `0x0301/0x0302/0x0401/0x2a05`. If the VVM link drops immediately after one, note which UUID; the follow-up is to stop forwarding that specific CCCD (add a deny-list in `_forward_write`). Record findings in the spec's "indicate-subscribe" section.
+
+- [ ] **Step 5: Revert boat to stable, capture results**
+
+Return the boat to `:1` (or leave on pr- for extended soak per user's call), and record the outcome (GO/partial/fallback-needed) in `docs/superpowers/specs/2026-07-20-ble-gatt-proxy-design.md`. If GO, cut a release and repoint per `boat-pi-deployment`.
+
+---
+
+## Self-Review
+
+**Spec coverage:** single-radio (Task 0 gate), no-MAC-clone name advertising (Tasks 5/7), open GATT (no security anywhere), advertise-only-while-up (Tasks 6/7 lifecycle), capture (Tasks 1/6), GATT clone (Task 3), central independence for SignalK (unchanged init path), indicate-subscribe risk (Task 8 step 4 + deny-list follow-up), opt-in default-off (Tasks 2/7), `bless` dep (Task 0). All covered.
+
+**Placeholder scan:** every code step has full code; commands have expected output; no TBD/TODO. The one deferred item (indicate deny-list) is explicitly a hardware-findings-driven follow-up, not a placeholder in shipped code.
+
+**Type consistency:** `mirror_profile(services) -> list[MirroredService]` used in Task 6; `MirroredChar(uuid, properties, permissions)` consistent across Tasks 3/5; `set_notification_observer`/`proxy_write`/`proxy_read`/`set_proxy_relay` names consistent across Tasks 4/6/7; `on_write(uuid,data)`/`on_read(uuid)->bytes` consistent across Tasks 5/6; `push_notification(uuid,data)` consistent across Tasks 5/6.

--- a/docs/superpowers/plans/2026-07-20-ble-gatt-proxy.md
+++ b/docs/superpowers/plans/2026-07-20-ble-gatt-proxy.md
@@ -49,8 +49,9 @@
 
 Append to `requirements.txt`:
 ```
-bless==0.2.6
+bless==0.3.0
 ```
+(API verified against 0.3.0: `BlessServer(name, loop=None)`, `add_new_service(uuid)`, `add_new_characteristic(service_uuid, char_uuid, properties, value, permissions)`, `start()`/`stop()`/`update_value(service_uuid, char_uuid)` are async/bool, `read_request_func`/`write_request_func` are instance attrs. **`GATTCharacteristicProperties` and `GATTAttributePermissions` are plain `enum.Flag`, NOT `IntFlag`** — accumulate from `P(0)`/`Perm(0)`, never from int `0`.)
 
 - [ ] **Step 2: Write the spike tool**
 
@@ -432,8 +433,8 @@ def mirror_profile(services) -> list:
     for service in services:
         chars = []
         for characteristic in service.characteristics:
-            props = 0
-            perms = 0
+            props = P(0)      # enum.Flag empty; NOT int 0 (int | Flag raises TypeError)
+            perms = Perm(0)
             for name in characteristic.properties:
                 flag = _PROP_MAP.get(name)
                 if flag is not None:

--- a/docs/superpowers/specs/2026-07-20-ble-gatt-proxy-design.md
+++ b/docs/superpowers/specs/2026-07-20-ble-gatt-proxy-design.md
@@ -1,0 +1,168 @@
+# BLE GATT Proxy — Design
+
+**Date:** 2026-07-20
+**Branch:** `ble-gatt-proxy` (off `main`)
+**Status:** Approved design; not yet implemented. Opt-in, unmerged until proven on boat hardware.
+
+## Problem
+
+The VVM engine-gateway hardware allows **only one BLE connection at a time**. When our
+connector holds that connection (to stream engine data into SignalK), the native
+SmartCraft / VesselView Mobile app can no longer connect to the engine. The user must
+choose: run the connector, *or* use the native app — not both.
+
+## Goal
+
+Let the native app and the connector both use the engine **at the same time**, over the
+single physical BLE link, by turning the connector into a **transparent BLE GATT proxy**:
+our app emulates the VVM as a BLE peripheral, the native app connects to *us*, and we relay
+every exchange to/from the real VVM (which we hold as a central). As a deliberate byproduct,
+the proxy **captures all relayed BLE traffic** to disk, feeding the ongoing fault-code /
+native-client protocol reverse-engineering effort.
+
+## Key facts that make this feasible
+
+- **Open GATT, no pairing/bonding/encryption.** The connector connects to the VVM over
+  unauthenticated GATT today (no `pair`/`bond`/`encrypt` anywhere in the code). The proxy
+  does not have to replicate any security handshake.
+- **The native app selects the VVM by name, not a pinned MAC.** The user picks
+  `VVM_84FD27D92CBE` from a scan list each time. So our peripheral can advertise the same
+  name and service UUIDs on its **own** address — **no MAC-cloning required**, and a
+  **single-radio** design is viable.
+- **Only our peripheral will be visible.** Because we hold the VVM's single connection slot,
+  the real VVM stops advertising, so the app's scan list shows only our peripheral (no
+  confusing duplicate).
+- **Controller supports both roles.** Boat Pi controller is Cypress/Broadcom **BT 5.0**;
+  BlueZ reports `Roles: central` and `Roles: peripheral`, 5 advertising instances. The one
+  thing still to prove empirically: advertising *while* the VVM link is held (first impl
+  step).
+
+## GATT surface to clone
+
+Custom service base `0000XXXX-0000-1000-8000-ec55f9f5b963`, characteristics:
+- `0x0302` startup, `0x0001` config, `0x0111` next, `0x0201` fault (indicate)
+- standard device-info chars (Model Number, Firmware Revision, Manufacturer Name, Device Name)
+- indicate control chars the app subscribes to: `0x0301 / 0x0302 / 0x0401 / 0x2a05`
+
+## Approach chosen
+
+**Single radio (`hci0`), concurrent central + peripheral, using `bless` for the peripheral
+role alongside the existing `bleak` central.** No extra hardware. Chosen over the
+dual-adapter option (add a USB BLE dongle) as the try-first approach; dual-adapter remains
+the documented fallback if the onboard controller can't sustain concurrent roles, or if we
+ever discover the app *does* pin the MAC (which would force two radios).
+
+Rejected: off-the-shelf BLE-MITM tools (gattacker / btlejack-style) — Node-based/aging,
+need two adapters anyway, and live outside our connector so they can't feed SignalK or reuse
+our decode logic.
+
+## Architecture
+
+One process, two BLE roles on `hci0`. Everything is behind an opt-in `proxy` mode
+(config flag, default off). With the flag off, the connector behaves **exactly as today**
+— zero regression risk.
+
+```
+   native app ──BLE(peripheral)──▶  VvmProxyPeripheral (bless GATT server)
+                                        │  writes / CCCD-subscribes / reads (app→VVM)
+                                        ▼
+                                    ProxyRelay ◀──────────┐ notifications (VVM→app)
+                                        │                 │
+                                        ▼                 │
+   real VVM ◀──BLE(central)──  BleDeviceConnection (existing bleak central)
+                                        │
+                                        ├──▶ SignalK decode/publish  (unchanged, always runs)
+                                        └──▶ TrafficCapture (timestamped hex, both directions)
+```
+
+## Components (each a small, independently-testable unit)
+
+1. **`BleDeviceConnection` (existing central)** — connects to the VVM, does its normal
+   bootstrap init so **SignalK streaming is independent of whether the app is connected**,
+   and receives all notifications. Minimal additions: a hook to fan out each upstream
+   notification, and methods to issue a proxied write/read *on behalf of the app*.
+2. **`GattProfileMirror`** — at upstream connect, discovers the VVM's
+   services/characteristics/descriptors and builds an identical `bless` profile (same UUIDs,
+   same notify/indicate/write/read properties, same CCCDs). Static device-info chars are read
+   once and served as fixed values.
+3. **`VvmProxyPeripheral` (`bless`)** — advertises as `VVM_84FD27D92CBE` with the cloned
+   services; the app connects here. Serves app reads from a value cache; surfaces app
+   writes/subscribes as events; pushes notifications to the app.
+4. **`ProxyRelay`** — the coordinator wiring central ↔ peripheral. Forwards VVM→app
+   (notifications) and app→VVM (writes, CCCD subscribes, reads), and owns the advertising
+   lifecycle.
+5. **`TrafficCapture`** — append-only, timestamped record of every relayed op (direction,
+   char UUID, operation, hex payload) → the protocol-capture file. Size-based rotation,
+   same pattern as `data.csv` / log rotation.
+
+## Data flow
+
+- **VVM → app:** the connector already subscribes to all notify chars (for SignalK). Each
+  notification is (a) decoded for SignalK *and* (b) forwarded to the matching peripheral
+  char; `bless` delivers it to the app if the app subscribed. The app rides the stream the
+  connector already pulls.
+- **App → VVM:** app writes a char (streaming-enable, channel config, engine-identity reads,
+  fault subscribe, CCCD) → relay forwards it verbatim to the VVM via the central. This is
+  what lets the app's own handshake reach the engine.
+- **Reads:** served from the value cache (device-info + last-notified values); on a cache
+  miss, a live proxy-read to the VVM.
+
+## Shared-session model (the main design tension)
+
+There is genuinely **one** VVM session with **one** shared config state. Both the connector's
+bootstrap init *and* the app's writes act on that single session, as if they were one client.
+The connector's decoder already follows the channel map dynamically, so app reconfiguration
+is tolerated. Model: **connector does a minimal bootstrap init so SignalK works with no app
+present, then stays passive and lets the app drive when connected.** Write-arbitration between
+the connector's init and the app's writes is the main risk area; the capture log is how we
+observe and resolve any real conflict.
+
+## Error handling / lifecycle
+
+- **Advertising gated on upstream health.** Advertise the peripheral **only while the VVM
+  link is up and streaming.** When the engine is off and the upstream link drops, stop
+  advertising and disconnect any connected app (mirrors a real VVM going off the air). Resume
+  advertising when upstream reconnects. Prevents the app connecting to a dead relay.
+- **Indicate-subscribe risk (biggest unknown).** The #37 outage suggested subscribing to the
+  indicate control chars (`0x301/0x302/0x401/0x2a05`) makes the VVM drop the link (ATT
+  `0x0e`) — which is why today's connector subscribes to **notify only**. But the native app
+  subscribes to those indicate chars and works, so the trigger was likely *how/when* our
+  connector subscribed, not the act itself. In proxy mode we forward the app's **exact CCCD
+  writes, in the app's exact order and timing**, replicating known-good behavior. Mitigation:
+  relay indicate-subscribes faithfully but **watch for an upstream drop** immediately after;
+  if a specific CCCD reproducibly kills the link, fall back to *not* forwarding that one (log
+  it; app still gets data). The capture log records the app's real sequence and finally
+  settles the #37 question.
+- **Concurrent-role failure on `hci0`** (Approach-A core risk): if advertising-while-connected
+  fails on real hardware, log loudly and **degrade to plain connector mode** (SignalK keeps
+  working). This is why the first implementation step is a standalone spike before any real
+  proxy code.
+- **App write conflicts with connector init:** connector does minimal bootstrap init, then
+  goes passive; capture surfaces any stomping to resolve iteratively.
+
+## Testing
+
+- **Unit (host, no hardware)**, following the existing `test_blelogic.py` fake-BLE style:
+  - `GattProfileMirror` clones a fake discovered profile correctly.
+  - `ProxyRelay` forwards notifications app-ward and writes/CCCD VVM-ward (fakes for both roles).
+  - `TrafficCapture` output format.
+  - Advertising is gated on upstream state.
+  - Proxy-mode-**off** leaves today's behavior byte-for-byte unchanged.
+- **Hardware spikes (on the boat, gated, in order):**
+  1. **Concurrency spike** — advertise a dummy peripheral on `hci0` while the connector holds
+     the VVM link. Go/no-go for Approach A.
+  2. **End-to-end** — native app connects through the proxy; engine data shows in the app
+     **and** SignalK keeps flowing **and** the capture file populates.
+  3. **Indicate-subscribe** — forwarded app subscriptions don't drop the upstream link.
+
+## Rollout
+
+- Opt-in `proxy.enabled` config (default off).
+- Deploy a `pr-<N>` image to the boat (never touching `:1`), iterate through the spikes.
+- Consider a release only once proven on hardware. Everything stays on `ble-gatt-proxy`
+  until then.
+
+## New dependency
+
+`bless` (BLE peripheral / GATT server over BlueZ D-Bus, asyncio). Pairs with the existing
+`bleak` central. Added to `requirements.txt`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 bleak==3.0.2
+bless==0.3.0
 PyYAML==6.0.3
 websockets==15.0.1

--- a/tests/test_ble_proxy_hooks.py
+++ b/tests/test_ble_proxy_hooks.py
@@ -61,3 +61,25 @@ def test_proxy_read_without_client_raises():
         assert False, "expected RuntimeError"
     except RuntimeError:
         pass
+
+
+def test_set_proxy_relay_ready_and_lost_called():
+    import asyncio
+    conn = _make_conn()
+
+    class _Relay:
+        def __init__(self):
+            self.ready = None
+            self.lost = False
+        async def on_upstream_ready(self, services):
+            self.ready = services
+        async def on_upstream_lost(self):
+            self.lost = True
+
+    relay = _Relay()
+    conn.set_proxy_relay(relay)
+    # the connection exposes helpers the loop calls; test them directly
+    asyncio.run(conn._proxy_notify_ready(["svc"]))
+    assert relay.ready == ["svc"]
+    asyncio.run(conn._proxy_notify_lost())
+    assert relay.lost is True

--- a/tests/test_ble_proxy_hooks.py
+++ b/tests/test_ble_proxy_hooks.py
@@ -1,0 +1,63 @@
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock
+
+from vvm_to_signalk.ble_connection import BleDeviceConnection, BleConnectionConfig
+
+
+@pytest.fixture(autouse=True)
+def _restore_event_loop():
+    """asyncio.run() (used below) closes its loop and clears the thread's
+    current event loop; BleDeviceConnection.__init__ creates an
+    asyncio.Future() and needs one to exist for later tests in this file
+    or in other modules (see tests/test_blelogic.py for the same pattern)."""
+    yield
+    asyncio.set_event_loop(asyncio.new_event_loop())
+
+
+class _FakeChar:
+    def __init__(self, uuid):
+        self.uuid = uuid
+
+
+def _make_conn():
+    cfg = BleConnectionConfig({"address": "AA:BB:CC:DD:EE:FF"})
+    return BleDeviceConnection(cfg, {})
+
+
+def test_observer_sees_every_notification():
+    conn = _make_conn()
+    seen = []
+    conn.set_notification_observer(lambda uuid, data: seen.append((uuid, bytes(data))))
+    # A channel notification (unknown item -> decode path) still reaches the observer.
+    conn.notification_handler(_FakeChar("00000201-0000-1000-8000-ec55f9f5b963"),
+                              bytearray(b"\x01\x02\x03"))
+    assert seen == [("00000201-0000-1000-8000-ec55f9f5b963", b"\x01\x02\x03")]
+
+
+def test_observer_cleared():
+    conn = _make_conn()
+    seen = []
+    conn.set_notification_observer(lambda uuid, data: seen.append(uuid))
+    conn.set_notification_observer(None)
+    conn.notification_handler(_FakeChar("uuid"), bytearray(b"\x00"))
+    assert seen == []
+
+
+def test_proxy_write_uses_active_client():
+    conn = _make_conn()
+    client = AsyncMock()
+    conn._active_client = client
+    asyncio.run(conn.proxy_write("uuid-x", b"\xaa", response=True))
+    client.write_gatt_char.assert_awaited_once_with("uuid-x", b"\xaa", response=True)
+
+
+def test_proxy_read_without_client_raises():
+    conn = _make_conn()
+    conn._active_client = None
+    try:
+        asyncio.run(conn.proxy_read("uuid-x"))
+        assert False, "expected RuntimeError"
+    except RuntimeError:
+        pass

--- a/tests/test_gatt_mirror.py
+++ b/tests/test_gatt_mirror.py
@@ -1,0 +1,37 @@
+from bless import GATTCharacteristicProperties as P, GATTAttributePermissions as Perm
+from vvm_to_signalk.gatt_mirror import mirror_profile
+
+
+class _FakeChar:
+    def __init__(self, uuid, properties):
+        self.uuid = uuid
+        self.properties = properties
+
+
+class _FakeService:
+    def __init__(self, uuid, chars):
+        self.uuid = uuid
+        self.characteristics = chars
+
+
+def test_mirror_maps_props_and_permissions():
+    services = [_FakeService("svc-1", [
+        _FakeChar("char-notify", ["notify"]),
+        _FakeChar("char-rw", ["read", "write"]),
+        _FakeChar("char-indicate", ["indicate"]),
+    ])]
+    mirrored = mirror_profile(services)
+    assert len(mirrored) == 1
+    svc = mirrored[0]
+    assert svc.uuid == "svc-1"
+    by_uuid = {c.uuid: c for c in svc.characteristics}
+
+    assert by_uuid["char-notify"].properties & P.notify
+    assert by_uuid["char-indicate"].properties & P.indicate
+    rw = by_uuid["char-rw"]
+    assert rw.properties & P.read
+    assert rw.properties & P.write
+    assert rw.permissions & Perm.readable
+    assert rw.permissions & Perm.writeable
+    # notify-only char is not writeable
+    assert not (by_uuid["char-notify"].permissions & Perm.writeable)

--- a/tests/test_proxy_config.py
+++ b/tests/test_proxy_config.py
@@ -1,0 +1,24 @@
+from vvm_to_signalk.proxy_config import ProxyConfig
+
+
+def test_default_disabled_and_invalid():
+    c = ProxyConfig()
+    assert c.enabled is False
+    assert c.valid is False
+    assert c.capture_file == "./logs/ble_capture.log"
+    assert c.advertised_name is None
+
+
+def test_read_enables_and_overrides():
+    c = ProxyConfig({"enabled": True, "capture-file": "/x/cap.log",
+                     "advertised-name": "VVM_TEST"})
+    assert c.enabled is True
+    assert c.valid is True
+    assert c.capture_file == "/x/cap.log"
+    assert c.advertised_name == "VVM_TEST"
+
+
+def test_read_none_is_noop():
+    c = ProxyConfig()
+    c.read(None)
+    assert c.enabled is False

--- a/tests/test_proxy_peripheral.py
+++ b/tests/test_proxy_peripheral.py
@@ -1,0 +1,101 @@
+import asyncio
+
+from vvm_to_signalk.gatt_mirror import MirroredService, MirroredChar
+from vvm_to_signalk.proxy_peripheral import VvmProxyPeripheral
+
+
+class _FakeServer:
+    def __init__(self, name, **kw):
+        self.name = name
+        self.services_added = []
+        self.chars_added = []
+        self.started = False
+        self.stopped = False
+        self.updated = []
+        self.read_request_func = None
+        self.write_request_func = None
+        self._values = {}
+
+    async def add_new_service(self, uuid):
+        self.services_added.append(uuid)
+
+    async def add_new_characteristic(self, svc, uuid, props, value, perms):
+        self.chars_added.append((svc, uuid))
+        self._values[uuid] = bytearray(value or b"")
+
+    def get_characteristic(self, uuid):
+        class _C:
+            pass
+        c = _C()
+        c.value = self._values.get(uuid, bytearray())
+        c.uuid = uuid
+        self._values[uuid] = c.value
+        return c
+
+    async def start(self):
+        self.started = True
+
+    async def stop(self):
+        self.stopped = True
+
+    def update_value(self, svc, uuid):
+        self.updated.append((svc, uuid))
+        return True
+
+
+def _peripheral(writes, reads):
+    mirrored = [MirroredService("svc-1", [
+        MirroredChar("char-a", 0x10, 0x01),
+        MirroredChar("char-b", 0x08, 0x02),
+    ])]
+    servers = {}
+
+    def factory(name, **kw):
+        s = _FakeServer(name, **kw)
+        servers["s"] = s
+        return s
+
+    p = VvmProxyPeripheral(
+        "VVM_TEST", mirrored,
+        on_write=lambda uuid, data: writes.append((uuid, bytes(data))),
+        on_read=lambda uuid: reads.get(uuid, b""),
+        server_factory=factory,
+    )
+    return p, servers
+
+
+def test_start_builds_profile_and_advertises():
+    p, servers = _peripheral([], {})
+    asyncio.run(p.start())
+    s = servers["s"]
+    assert s.services_added == ["svc-1"]
+    assert set(u for _, u in s.chars_added) == {"char-a", "char-b"}
+    assert s.started is True
+
+
+def test_push_notification_updates_value():
+    p, servers = _peripheral([], {})
+    asyncio.run(p.start())
+    asyncio.run(p.push_notification("char-a", b"\x99"))
+    s = servers["s"]
+    assert ("svc-1", "char-a") in s.updated
+
+
+def test_push_unknown_uuid_is_ignored():
+    p, servers = _peripheral([], {})
+    asyncio.run(p.start())
+    asyncio.run(p.push_notification("nope", b"\x01"))  # must not raise
+    assert ("svc-1", "nope") not in servers["s"].updated
+
+
+def test_write_callback_invoked():
+    writes = []
+    p, servers = _peripheral(writes, {})
+    asyncio.run(p.start())
+    s = servers["s"]
+    # simulate bless invoking the registered write handler
+
+    class _C:
+        uuid = "char-b"
+    s.write_request_func(_C(), bytearray(b"\x42"))
+    assert writes == [("char-b", b"\x42")]

--- a/tests/test_proxy_relay.py
+++ b/tests/test_proxy_relay.py
@@ -1,0 +1,98 @@
+import asyncio
+
+from vvm_to_signalk.proxy_config import ProxyConfig
+from vvm_to_signalk.proxy_relay import ProxyRelay
+
+
+class _FakeConn:
+    def __init__(self):
+        self.observer = None
+        self.writes = []
+    def set_notification_observer(self, cb):
+        self.observer = cb
+    async def proxy_write(self, uuid, data, response=True):
+        self.writes.append((uuid, bytes(data)))
+
+
+class _FakePeripheral:
+    def __init__(self, name, mirrored, on_write, on_read, **kw):
+        self.name = name
+        self.on_write = on_write
+        self.on_read = on_read
+        self.started = False
+        self.stopped = False
+        self.pushed = []
+    async def start(self):
+        self.started = True
+    async def stop(self):
+        self.stopped = True
+    async def push_notification(self, uuid, data):
+        self.pushed.append((uuid, bytes(data)))
+
+
+class _FakeChar:
+    def __init__(self, uuid, props):
+        self.uuid = uuid
+        self.properties = props
+
+
+class _FakeService:
+    def __init__(self, uuid, chars):
+        self.uuid = uuid
+        self.characteristics = chars
+
+
+def _relay():
+    conn = _FakeConn()
+    made = {}
+    def pf(name, mirrored, on_write, on_read, **kw):
+        p = _FakePeripheral(name, mirrored, on_write, on_read, **kw)
+        made["p"] = p
+        return p
+    relay = ProxyRelay(conn, ProxyConfig({"enabled": True}), "VVM_TEST",
+                       asyncio.get_event_loop(), peripheral_factory=pf)
+    return relay, conn, made
+
+
+def test_ready_starts_peripheral_and_registers_observer():
+    async def run():
+        relay, conn, made = _relay()
+        services = [_FakeService("svc", [_FakeChar("c1", ["notify"])])]
+        await relay.on_upstream_ready(services)
+        assert made["p"].started is True
+        assert conn.observer is not None
+    asyncio.run(run())
+
+
+def test_notification_is_cached_and_forwarded():
+    async def run():
+        relay, conn, made = _relay()
+        services = [_FakeService("svc", [_FakeChar("c1", ["notify"])])]
+        await relay.on_upstream_ready(services)
+        conn.observer("c1", b"\x07")           # simulate a VVM notification
+        await asyncio.sleep(0)                  # let scheduled task run
+        assert ("c1", b"\x07") in made["p"].pushed
+        assert relay._serve_read("c1") == b"\x07"   # cached for reads
+    asyncio.run(run())
+
+
+def test_app_write_forwarded_to_vvm():
+    async def run():
+        relay, conn, made = _relay()
+        services = [_FakeService("svc", [_FakeChar("c1", ["write"])])]
+        await relay.on_upstream_ready(services)
+        made["p"].on_write("c1", b"\x42")       # simulate app write
+        await asyncio.sleep(0)
+        assert ("c1", b"\x42") in conn.writes
+    asyncio.run(run())
+
+
+def test_lost_stops_peripheral_and_clears_observer():
+    async def run():
+        relay, conn, made = _relay()
+        services = [_FakeService("svc", [_FakeChar("c1", ["notify"])])]
+        await relay.on_upstream_ready(services)
+        await relay.on_upstream_lost()
+        assert made["p"].stopped is True
+        assert conn.observer is None
+    asyncio.run(run())

--- a/tests/test_proxy_relay.py
+++ b/tests/test_proxy_relay.py
@@ -5,13 +5,21 @@ from vvm_to_signalk.proxy_relay import ProxyRelay
 
 
 class _FakeConn:
-    def __init__(self):
+    def __init__(self, read_values=None, write_error=None):
         self.observer = None
         self.writes = []
+        self.reads = []
+        self._read_values = read_values or {}
+        self._write_error = write_error
     def set_notification_observer(self, cb):
         self.observer = cb
     async def proxy_write(self, uuid, data, response=True):
+        if self._write_error is not None:
+            raise self._write_error
         self.writes.append((uuid, bytes(data)))
+    async def proxy_read(self, uuid):
+        self.reads.append(uuid)
+        return self._read_values.get(uuid, b"")
 
 
 class _FakePeripheral:
@@ -42,8 +50,8 @@ class _FakeService:
         self.characteristics = chars
 
 
-def _relay():
-    conn = _FakeConn()
+def _relay(conn=None):
+    conn = conn if conn is not None else _FakeConn()
     made = {}
     def pf(name, mirrored, on_write, on_read, **kw):
         p = _FakePeripheral(name, mirrored, on_write, on_read, **kw)
@@ -95,4 +103,33 @@ def test_lost_stops_peripheral_and_clears_observer():
         await relay.on_upstream_lost()
         assert made["p"].stopped is True
         assert conn.observer is None
+    asyncio.run(run())
+
+
+def test_readable_chars_are_prefetched_into_read_cache():
+    async def run():
+        conn = _FakeConn(read_values={"c1": b"MODEL-X"})
+        relay, conn, made = _relay(conn)
+        services = [_FakeService("svc", [
+            _FakeChar("c1", ["read"]),
+            _FakeChar("c2", ["notify"]),
+        ])]
+        await relay.on_upstream_ready(services)
+        assert relay._serve_read("c1") == b"MODEL-X"
+        assert "c1" in conn.reads
+        assert "c2" not in conn.reads
+    asyncio.run(run())
+
+
+def test_forward_write_failure_is_logged_not_raised(caplog):
+    async def run():
+        conn = _FakeConn(write_error=RuntimeError("boom"))
+        relay, conn, made = _relay(conn)
+        services = [_FakeService("svc", [_FakeChar("c1", ["write"])])]
+        await relay.on_upstream_ready(services)
+        with caplog.at_level("WARNING"):
+            made["p"].on_write("c1", b"\x42")   # should not raise
+            for _ in range(5):
+                await asyncio.sleep(0)
+        assert "proxy scheduled op failed" in caplog.text
     asyncio.run(run())

--- a/tests/test_traffic_capture.py
+++ b/tests/test_traffic_capture.py
@@ -28,4 +28,5 @@ def test_empty_data_has_empty_hex(tmp_path):
     ts = datetime(2026, 7, 20, 0, 0, 0, tzinfo=timezone.utc)
     cap.record("app->vvm", "subscribe", "uuid", b"", now=ts)
     cap.close()
-    assert path.read_text().strip().endswith("subscribe uuid")
+    line = path.read_text().rstrip("\n")
+    assert line.endswith("subscribe uuid ")

--- a/tests/test_traffic_capture.py
+++ b/tests/test_traffic_capture.py
@@ -1,0 +1,31 @@
+from datetime import datetime, timezone
+from vvm_to_signalk.traffic_capture import TrafficCapture
+
+
+def test_record_writes_one_line(tmp_path):
+    path = tmp_path / "capture.log"
+    cap = TrafficCapture(str(path))
+    ts = datetime(2026, 7, 20, 1, 2, 3, tzinfo=timezone.utc)
+    cap.record("app->vvm", "write", "00000001-0000-1000-8000-ec55f9f5b963",
+               bytes.fromhex("a1b2"), now=ts)
+    cap.close()
+    line = path.read_text().strip()
+    assert line == ("2026-07-20T01:02:03+00:00 app->vvm write "
+                    "00000001-0000-1000-8000-ec55f9f5b963 a1b2")
+
+
+def test_disabled_capture_writes_nothing(tmp_path):
+    path = tmp_path / "capture.log"
+    cap = TrafficCapture(str(path), enabled=False)
+    cap.record("vvm->app", "notify", "x", b"\x01", now=datetime.now(timezone.utc))
+    cap.close()
+    assert not path.exists()
+
+
+def test_empty_data_has_empty_hex(tmp_path):
+    path = tmp_path / "capture.log"
+    cap = TrafficCapture(str(path))
+    ts = datetime(2026, 7, 20, 0, 0, 0, tzinfo=timezone.utc)
+    cap.record("app->vvm", "subscribe", "uuid", b"", now=ts)
+    cap.close()
+    assert path.read_text().strip().endswith("subscribe uuid")

--- a/tests/test_vvm_monitor.py
+++ b/tests/test_vvm_monitor.py
@@ -160,3 +160,15 @@ def test_capture_bytes_produce_expected_values():
     assert rx.values[(1, 1)] == 600.0
     assert round(rx.values[(232, 1)], 3) == 14.523
     assert rx.faults and rx.faults[0].fault_key == "1111-Legacy"
+
+def test_vvmconfig_reads_proxy_section():
+    from vvm_to_signalk.vvm_monitor import VVMConfig
+    cfg = VVMConfig({"proxy": {"enabled": True, "advertised-name": "VVM_X"}})
+    assert cfg.proxy.enabled is True
+    assert cfg.proxy.advertised_name == "VVM_X"
+
+
+def test_vvmconfig_proxy_default_off():
+    from vvm_to_signalk.vvm_monitor import VVMConfig
+    cfg = VVMConfig({})
+    assert cfg.proxy.enabled is False

--- a/tools/proxy_concurrency_spike.py
+++ b/tools/proxy_concurrency_spike.py
@@ -1,0 +1,49 @@
+"""Hardware go/no-go for the single-radio BLE proxy (Approach A).
+
+Connects to the VVM as a central AND advertises a dummy peripheral on the same
+adapter at the same time. If both hold for ~60s with no error/disconnect, the Pi
+controller supports the concurrent central+peripheral roles the proxy needs.
+
+Run ON THE BOAT PI (engine/VVM powered on):
+    python3 -m tools.proxy_concurrency_spike --address 84:FD:27:D9:2C:BE
+"""
+import argparse
+import asyncio
+import logging
+
+from bleak import BleakClient
+from bless import BlessServer, GATTCharacteristicProperties, GATTAttributePermissions
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+log = logging.getLogger("spike")
+
+DUMMY_SERVICE = "0000fff0-0000-1000-8000-00805f9b34fb"
+DUMMY_CHAR = "0000fff1-0000-1000-8000-00805f9b34fb"
+
+
+async def main(address: str, name: str, hold: float):
+    server = BlessServer(name=name)
+    await server.add_new_service(DUMMY_SERVICE)
+    await server.add_new_characteristic(
+        DUMMY_SERVICE, DUMMY_CHAR,
+        GATTCharacteristicProperties.read | GATTCharacteristicProperties.notify,
+        bytearray(b"\x00"),
+        GATTAttributePermissions.readable,
+    )
+    async with BleakClient(address, timeout=20.0) as client:
+        log.info("CENTRAL connected to VVM %s", address)
+        await server.start()
+        log.info("PERIPHERAL advertising as %s -- both roles now live", name)
+        log.info("Holding both for %.0fs; watch for disconnects/errors...", hold)
+        await asyncio.sleep(hold)
+        await server.stop()
+        log.info("GO: both roles held for the full window with no error")
+
+
+if __name__ == "__main__":
+    p = argparse.ArgumentParser()
+    p.add_argument("--address", required=True, help="VVM BLE address")
+    p.add_argument("--name", default="VVM_SPIKE_TEST")
+    p.add_argument("--hold", type=float, default=60.0)
+    args = p.parse_args()
+    asyncio.run(main(args.address, args.name, args.hold))

--- a/vvm_monitor.example.yaml
+++ b/vvm_monitor.example.yaml
@@ -22,5 +22,14 @@ csv:
   enabled: true
   filename: ./logs/data.csv
   interval: 1.0
-  
-  
+
+# Optional: BLE GATT proxy so the native SmartCraft app can connect through
+# this connector to the engine (the VVM only allows one BLE connection).
+# Default: disabled. Requires an adapter that supports concurrent
+# central+peripheral roles on one radio.
+proxy:
+  enabled: false
+  # File that captures all relayed BLE traffic (timestamped hex).
+  capture-file: ./logs/ble_capture.log
+  # Name to advertise to the app. Defaults to ble-device.name when omitted.
+  # advertised-name: "VVM_84FD27D92CBE"

--- a/vvm_to_signalk/ble_connection.py
+++ b/vvm_to_signalk/ble_connection.py
@@ -45,10 +45,33 @@ class BleDeviceConnection:
         self._fault_subscribe_pending = False   # True only between attempting and confirming
         # Active paged UserVar string read (protocol-map §4); None when idle.
         self._paged_read = None
+        self._active_client = None          # set while a BLE client is connected
+        self._notification_observer = None  # proxy fan-out callback (uuid, data)
 
     def accept_data_receiver(self, receiver: EngineDataReceiver) -> None:
         """Add a new data receiver to the collection"""
         self.__data_receivers.append(receiver)
+
+    def set_notification_observer(self, callback) -> None:
+        """Register a callback(uuid: str, data: bytes) invoked for every
+        notification, in addition to normal decoding. None clears it.
+        Used by the BLE proxy to forward the VVM stream to the native app."""
+        self._notification_observer = callback
+
+    async def proxy_write(self, uuid: str, data: bytes, response: bool = True) -> None:
+        """Write to the connected VVM on the app's behalf (proxy mode)."""
+        client = self._active_client
+        if client is None:
+            logger.warning("proxy_write dropped (no active VVM connection): %s", uuid)
+            return
+        await client.write_gatt_char(uuid, data, response=response)
+
+    async def proxy_read(self, uuid: str) -> bytes:
+        """Read a characteristic from the connected VVM (proxy mode)."""
+        client = self._active_client
+        if client is None:
+            raise RuntimeError("not connected")
+        return bytes(await client.read_gatt_char(uuid))
 
     @property
     def device_address(self):
@@ -134,6 +157,7 @@ class BleDeviceConnection:
 
                 self._set_health(True, "Connected to device")
                 connected = True
+                self._active_client = client
                 self._reset_unparsed_tracking()
 
                 logger.info("Retrieving device identification metadata...")
@@ -174,6 +198,7 @@ class BleDeviceConnection:
         except Exception as e:
             self._set_health(False, f"Device error: {e}")
         finally:
+            self._active_client = None
             self._finalize_fault_subscribe_state()
             if monitor_task:
                 monitor_task.cancel()
@@ -378,6 +403,12 @@ class BleDeviceConnection:
     def notification_handler(self, characteristic: BleakGATTCharacteristic, data: bytearray):
         """Handles BLE notifications and indications."""
         self.__last_message_time = asyncio.get_event_loop().time()
+        observer = self._notification_observer
+        if observer is not None:
+            try:
+                observer(characteristic.uuid, bytes(data))
+            except Exception as e:  # never let the proxy break decoding
+                logger.warning("notification observer error: %s", e)
         uuid = characteristic.uuid
         # Guard the hex() conversion: this runs on every notification, so avoid
         # paying for it when debug logging is disabled.

--- a/vvm_to_signalk/ble_connection.py
+++ b/vvm_to_signalk/ble_connection.py
@@ -47,6 +47,7 @@ class BleDeviceConnection:
         self._paged_read = None
         self._active_client = None          # set while a BLE client is connected
         self._notification_observer = None  # proxy fan-out callback (uuid, data)
+        self._proxy_relay = None            # ProxyRelay attached via set_proxy_relay
 
     def accept_data_receiver(self, receiver: EngineDataReceiver) -> None:
         """Add a new data receiver to the collection"""
@@ -72,6 +73,24 @@ class BleDeviceConnection:
         if client is None:
             raise RuntimeError("not connected")
         return bytes(await client.read_gatt_char(uuid))
+
+    def set_proxy_relay(self, relay) -> None:
+        """Attach a ProxyRelay to mirror the VVM link to the native app."""
+        self._proxy_relay = relay
+
+    async def _proxy_notify_ready(self, services) -> None:
+        if self._proxy_relay is not None:
+            try:
+                await self._proxy_relay.on_upstream_ready(services)
+            except Exception as e:
+                logger.warning("Proxy start failed (continuing without it): %s", e)
+
+    async def _proxy_notify_lost(self) -> None:
+        if self._proxy_relay is not None:
+            try:
+                await self._proxy_relay.on_upstream_lost()
+            except Exception as e:
+                logger.warning("Proxy stop error: %s", e)
 
     @property
     def device_address(self):
@@ -184,6 +203,7 @@ class BleDeviceConnection:
                 # enabled, mirroring the native app (btsnoop capture). Isolated so
                 # a device that rejects it disables faults but keeps streaming.
                 await self._subscribe_fault_alert(client)
+                await self._proxy_notify_ready(client.services)
 
                 # Start the streaming monitor if a timeout is configured
                 if self.__config.streaming_timeout > 0:
@@ -198,6 +218,7 @@ class BleDeviceConnection:
         except Exception as e:
             self._set_health(False, f"Device error: {e}")
         finally:
+            await self._proxy_notify_lost()
             self._active_client = None
             self._finalize_fault_subscribe_state()
             if monitor_task:

--- a/vvm_to_signalk/csv_writer.py
+++ b/vvm_to_signalk/csv_writer.py
@@ -96,6 +96,8 @@ class CsvWriterConfig:
 
     def read(self, data: dict):
         """Loads settings from a dictionary"""
+        if data is None:
+            return
         self.__enabled = data.get("enabled", self.__enabled)
         self.__filename = data.get("filename", self.__filename)
         self.__flush_interval = data.get("interval", self.__flush_interval)

--- a/vvm_to_signalk/gatt_mirror.py
+++ b/vvm_to_signalk/gatt_mirror.py
@@ -1,0 +1,46 @@
+"""Mirror a discovered VVM GATT profile into bless service/characteristic specs."""
+from dataclasses import dataclass
+
+from bless import GATTCharacteristicProperties as P, GATTAttributePermissions as Perm
+
+_PROP_MAP = {
+    "read": P.read,
+    "write": P.write,
+    "write-without-response": P.write_without_response,
+    "notify": P.notify,
+    "indicate": P.indicate,
+}
+
+
+@dataclass
+class MirroredChar:
+    uuid: str
+    properties: int
+    permissions: int
+
+
+@dataclass
+class MirroredService:
+    uuid: str
+    characteristics: list
+
+
+def mirror_profile(services) -> list:
+    """Convert bleak-discovered services into a list of MirroredService."""
+    result = []
+    for service in services:
+        chars = []
+        for characteristic in service.characteristics:
+            props = P(0)      # enum.Flag empty; NOT int 0 (int | Flag raises TypeError)
+            perms = Perm(0)
+            for name in characteristic.properties:
+                flag = _PROP_MAP.get(name)
+                if flag is not None:
+                    props |= flag
+                if name == "read":
+                    perms |= Perm.readable
+                if name in ("write", "write-without-response"):
+                    perms |= Perm.writeable
+            chars.append(MirroredChar(characteristic.uuid, props, perms))
+        result.append(MirroredService(service.uuid, chars))
+    return result

--- a/vvm_to_signalk/proxy_config.py
+++ b/vvm_to_signalk/proxy_config.py
@@ -1,0 +1,37 @@
+"""Configuration for the BLE GATT proxy mode."""
+
+
+class ProxyConfig:
+    """Parses the optional `proxy` config section. Disabled by default."""
+
+    def __init__(self, data: dict | None = None):
+        self._enabled = False
+        self._capture_file = "./logs/ble_capture.log"
+        self._advertised_name = None
+        if data is not None:
+            self.read(data)
+
+    def read(self, data: dict | None) -> None:
+        """Read proxy settings from a dict; None is a no-op."""
+        if data is None:
+            return
+        self._enabled = bool(data.get("enabled", self._enabled))
+        self._capture_file = data.get("capture-file", self._capture_file)
+        self._advertised_name = data.get("advertised-name", self._advertised_name)
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    @property
+    def capture_file(self) -> str:
+        return self._capture_file
+
+    @property
+    def advertised_name(self):
+        return self._advertised_name
+
+    @property
+    def valid(self) -> bool:
+        """The proxy is only 'valid' (should be constructed) when enabled."""
+        return self._enabled

--- a/vvm_to_signalk/proxy_peripheral.py
+++ b/vvm_to_signalk/proxy_peripheral.py
@@ -1,0 +1,70 @@
+"""bless GATT-server peripheral that emulates the VVM to the native app."""
+import logging
+
+from bless import BlessServer
+
+logger = logging.getLogger(__name__)
+
+
+class VvmProxyPeripheral:
+    """Advertises a cloned VVM profile and relays app<->VVM via callbacks."""
+
+    def __init__(self, name, mirrored, on_write, on_read, server_factory=BlessServer):
+        self._name = name
+        self._mirrored = mirrored
+        self._on_write = on_write
+        self._on_read = on_read
+        self._server_factory = server_factory
+        self._server = None
+        self._char_to_service = {}
+
+    async def start(self) -> None:
+        """Build the cloned profile and begin advertising."""
+        server = self._server_factory(name=self._name)
+        server.read_request_func = self._handle_read
+        server.write_request_func = self._handle_write
+        for service in self._mirrored:
+            await server.add_new_service(service.uuid)
+            for char in service.characteristics:
+                self._char_to_service[char.uuid] = service.uuid
+                await server.add_new_characteristic(
+                    service.uuid, char.uuid, char.properties,
+                    bytearray(), char.permissions)
+        await server.start()
+        self._server = server
+        logger.info("Proxy peripheral advertising as %s (%d chars)",
+                    self._name, len(self._char_to_service))
+
+    async def stop(self) -> None:
+        """Stop advertising and disconnect the app."""
+        if self._server is not None:
+            await self._server.stop()
+            self._server = None
+
+    async def push_notification(self, uuid: str, data: bytes) -> None:
+        """Deliver a VVM notification to a subscribed app."""
+        if self._server is None:
+            return
+        service_uuid = self._char_to_service.get(uuid)
+        if service_uuid is None:
+            return
+        char = self._server.get_characteristic(uuid)
+        if char is None:
+            return
+        char.value = bytearray(data)
+        self._server.update_value(service_uuid, uuid)
+
+    def _handle_read(self, characteristic, **kwargs):
+        """bless read callback: return the current value for the app."""
+        try:
+            return bytearray(self._on_read(characteristic.uuid))
+        except Exception as e:
+            logger.warning("proxy read error on %s: %s", characteristic.uuid, e)
+            return bytearray()
+
+    def _handle_write(self, characteristic, value, **kwargs):
+        """bless write callback: forward the app's write to the VVM."""
+        try:
+            self._on_write(characteristic.uuid, bytes(value))
+        except Exception as e:
+            logger.warning("proxy write error on %s: %s", characteristic.uuid, e)

--- a/vvm_to_signalk/proxy_relay.py
+++ b/vvm_to_signalk/proxy_relay.py
@@ -1,0 +1,80 @@
+"""Coordinator wiring the VVM central to the app-facing peripheral."""
+import asyncio
+import logging
+
+from .gatt_mirror import mirror_profile
+from .proxy_peripheral import VvmProxyPeripheral
+
+logger = logging.getLogger(__name__)
+
+
+class ProxyRelay:
+    """Relays notifications VVM->app and writes/reads app->VVM."""
+
+    def __init__(self, connection, proxy_config, advertised_name, loop,
+                 peripheral_factory=VvmProxyPeripheral, capture=None):
+        self._conn = connection
+        self._config = proxy_config
+        self._name = advertised_name
+        self._loop = loop
+        self._peripheral_factory = peripheral_factory
+        self._capture = capture
+        self._peripheral = None
+        self._read_cache = {}
+
+    async def on_upstream_ready(self, services) -> None:
+        """VVM link is up: clone the profile, advertise, start relaying."""
+        mirrored = mirror_profile(services)
+        self._peripheral = self._peripheral_factory(
+            self._name, mirrored,
+            on_write=self._forward_write,
+            on_read=self._serve_read)
+        await self._peripheral.start()
+        self._conn.set_notification_observer(self._forward_notification)
+        logger.info("Proxy relay active (advertising %s)", self._name)
+
+    async def on_upstream_lost(self) -> None:
+        """VVM link dropped: stop advertising and clear the relay."""
+        self._conn.set_notification_observer(None)
+        if self._peripheral is not None:
+            await self._peripheral.stop()
+            self._peripheral = None
+        self._read_cache.clear()
+        logger.info("Proxy relay stopped (upstream lost)")
+
+    def _forward_notification(self, uuid, data):
+        """Observer body (called from the central's notification path)."""
+        self._read_cache[uuid] = bytes(data)
+        if self._capture is not None:
+            self._capture.record("vvm->app", "notify", uuid, bytes(data))
+        peripheral = self._peripheral
+        if peripheral is not None:
+            self._loop.create_task(peripheral.push_notification(uuid, bytes(data)))
+
+    def _forward_write(self, uuid, data):
+        """Peripheral on_write body (called from bless callback thread/loop)."""
+        if self._capture is not None:
+            self._capture.record("app->vvm", "write", uuid, bytes(data))
+        coro = self._conn.proxy_write(uuid, bytes(data))
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+        if running_loop is self._loop:
+            # bless's callback happened to fire on the relay's own loop
+            # (as it does in tests, and in some bless backends); scheduling
+            # via create_task avoids the two-iteration lag of
+            # run_coroutine_threadsafe when there's no separate thread to
+            # bridge from.
+            self._loop.create_task(coro)
+        else:
+            # Real bless callbacks typically fire off-loop (a different
+            # thread/executor); bridge back onto the relay's loop safely.
+            asyncio.run_coroutine_threadsafe(coro, self._loop)
+
+    def _serve_read(self, uuid) -> bytes:
+        """Peripheral on_read body: last-known value for the char."""
+        value = self._read_cache.get(uuid, b"")
+        if self._capture is not None:
+            self._capture.record("app->vvm", "read", uuid, value)
+        return value

--- a/vvm_to_signalk/proxy_relay.py
+++ b/vvm_to_signalk/proxy_relay.py
@@ -1,5 +1,6 @@
 """Coordinator wiring the VVM central to the app-facing peripheral."""
 import asyncio
+import concurrent.futures
 import logging
 
 from .gatt_mirror import mirror_profile
@@ -21,9 +22,17 @@ class ProxyRelay:
         self._capture = capture
         self._peripheral = None
         self._read_cache = {}
+        self._pending = set()
 
     async def on_upstream_ready(self, services) -> None:
         """VVM link is up: clone the profile, advertise, start relaying."""
+        for service in services:
+            for ch in service.characteristics:
+                if "read" in ch.properties:
+                    try:
+                        self._read_cache[ch.uuid] = await self._conn.proxy_read(ch.uuid)
+                    except Exception as e:
+                        logger.debug("proxy pre-read failed for %s: %s", ch.uuid, e)
         mirrored = mirror_profile(services)
         self._peripheral = self._peripheral_factory(
             self._name, mirrored,
@@ -49,28 +58,43 @@ class ProxyRelay:
             self._capture.record("vvm->app", "notify", uuid, bytes(data))
         peripheral = self._peripheral
         if peripheral is not None:
-            self._loop.create_task(peripheral.push_notification(uuid, bytes(data)))
+            self._schedule(peripheral.push_notification(uuid, bytes(data)))
 
     def _forward_write(self, uuid, data):
         """Peripheral on_write body (called from bless callback thread/loop)."""
         if self._capture is not None:
             self._capture.record("app->vvm", "write", uuid, bytes(data))
-        coro = self._conn.proxy_write(uuid, bytes(data))
+        self._schedule(self._conn.proxy_write(uuid, bytes(data)))
+
+    def _schedule(self, coro):
+        """Schedule a coroutine on the relay's loop from on- or off-loop context,
+        retaining the handle and logging any exception (fire-and-forget otherwise
+        swallows failures — e.g. a failed app->VVM write)."""
         try:
             running_loop = asyncio.get_running_loop()
         except RuntimeError:
             running_loop = None
         if running_loop is self._loop:
-            # bless's callback happened to fire on the relay's own loop
-            # (as it does in tests, and in some bless backends); scheduling
-            # via create_task avoids the two-iteration lag of
-            # run_coroutine_threadsafe when there's no separate thread to
-            # bridge from.
-            self._loop.create_task(coro)
+            # Caller happened to fire on the relay's own loop (as it does in
+            # tests, and in some bless backends); scheduling via create_task
+            # avoids the two-iteration lag of run_coroutine_threadsafe when
+            # there's no separate thread to bridge from.
+            handle = self._loop.create_task(coro)
+            self._pending.add(handle)
         else:
             # Real bless callbacks typically fire off-loop (a different
             # thread/executor); bridge back onto the relay's loop safely.
-            asyncio.run_coroutine_threadsafe(coro, self._loop)
+            handle = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        handle.add_done_callback(self._on_scheduled_done)
+
+    def _on_scheduled_done(self, handle):
+        self._pending.discard(handle)
+        try:
+            exc = handle.exception()
+        except (asyncio.CancelledError, concurrent.futures.CancelledError):
+            return
+        if exc is not None:
+            logger.warning("proxy scheduled op failed: %s", exc)
 
     def _serve_read(self, uuid) -> bytes:
         """Peripheral on_read body: last-known value for the char."""

--- a/vvm_to_signalk/traffic_capture.py
+++ b/vvm_to_signalk/traffic_capture.py
@@ -1,0 +1,31 @@
+"""Append-only capture of relayed BLE proxy traffic."""
+import logging
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+
+class TrafficCapture:
+    """Records every relayed GATT operation as one timestamped hex line."""
+
+    def __init__(self, path: str, enabled: bool = True):
+        self._enabled = enabled
+        self._path = path
+        self._fh = None
+        if self._enabled:
+            self._fh = open(path, "a", encoding="utf-8")  # noqa: SIM115
+
+    def record(self, direction: str, operation: str, uuid: str, data: bytes,
+               now: datetime | None = None) -> None:
+        """Append one capture line. No-op when disabled."""
+        if not self._enabled or self._fh is None:
+            return
+        ts = (now or datetime.now(timezone.utc)).isoformat()
+        self._fh.write(f"{ts} {direction} {operation} {uuid} {data.hex()}\n")
+        self._fh.flush()
+
+    def close(self) -> None:
+        """Close the capture file."""
+        if self._fh is not None:
+            self._fh.close()
+            self._fh = None

--- a/vvm_to_signalk/traffic_capture.py
+++ b/vvm_to_signalk/traffic_capture.py
@@ -1,8 +1,5 @@
 """Append-only capture of relayed BLE proxy traffic."""
-import logging
 from datetime import datetime, timezone
-
-logger = logging.getLogger(__name__)
 
 
 class TrafficCapture:
@@ -10,7 +7,6 @@ class TrafficCapture:
 
     def __init__(self, path: str, enabled: bool = True):
         self._enabled = enabled
-        self._path = path
         self._fh = None
         if self._enabled:
             self._fh = open(path, "a", encoding="utf-8")  # noqa: SIM115

--- a/vvm_to_signalk/vvm_monitor.py
+++ b/vvm_to_signalk/vvm_monitor.py
@@ -13,6 +13,9 @@ from .ble_connection import BleConnectionConfig, BleDeviceConnection
 from .signalk_publisher import SignalKConfig, SignalKPublisher
 from .csv_writer import CsvWriter, CsvWriterConfig
 from .healthcheck import format_heartbeat
+from .proxy_config import ProxyConfig
+from .proxy_relay import ProxyRelay
+from .traffic_capture import TrafficCapture
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +64,14 @@ class VesselViewMobileDataRecorder:
                 self.__ble_connection.accept_data_receiver(self.__csv_writer)
         else:
             logger.warning("Skipping csv output - configuration is invalid.")
+
+        if self.__ble_connection is not None and config.proxy.valid:
+            capture = TrafficCapture(config.proxy.capture_file)
+            adv_name = config.proxy.advertised_name or config.bluetooth.device_name
+            relay = ProxyRelay(self.__ble_connection, config.proxy, adv_name,
+                               loop, capture=capture)
+            self.__ble_connection.set_proxy_relay(relay)
+            logger.info("BLE GATT proxy enabled (advertising as %s)", adv_name)
 
         background_tasks = set()
         async with asyncio.TaskGroup() as tg:
@@ -232,6 +243,7 @@ class VVMConfig:
         self._ble_config = BleConnectionConfig()
         self._signalk_config = SignalKConfig()
         self._csv_config = CsvWriterConfig()
+        self._proxy_config = ProxyConfig()
 
         self._logging_level = logging.INFO
         self._logging_file = "./logs/vvm_monitor.log"
@@ -250,6 +262,7 @@ class VVMConfig:
         self.signalk.read(data.get('signalk'))
         self.bluetooth.read(data.get('ble-device'))
         self.csv.read(data.get('csv'))
+        self.proxy.read(data.get('proxy'))
 
         if (log_config := data.get('logging')) is not None:
             if (level_str := log_config.get('level')) is not None:
@@ -288,6 +301,15 @@ class VVMConfig:
     @csv.setter
     def csv(self, value):
         self._csv_config = value
+
+    @property
+    def proxy(self):
+        """Configuration for the BLE GATT proxy mode."""
+        return self._proxy_config
+
+    @proxy.setter
+    def proxy(self, value):
+        self._proxy_config = value
 
     @property
     def logging_level(self):


### PR DESCRIPTION
## What this does

Turns the connector into a **transparent BLE GATT proxy** so the native SmartCraft / VesselView Mobile app and the connector can both use the VVM **at the same time**, over the engine gateway's single BLE connection slot. Today, when the connector holds that slot the native app can't connect; this makes them coexist.

- The existing `bleak` **central** keeps holding the VVM link and feeding SignalK (unchanged).
- A new `bless` **peripheral** clones the VVM's GATT profile and advertises as `VVM_…`; the app connects to it.
- A `ProxyRelay` forwards notifications VVM→app and writes/reads app→VVM.
- A `TrafficCapture` logs every relayed op (timestamped hex) → feeds the fault-code / native-client reverse-engineering effort.

**Opt-in, default OFF.** With no `proxy:` config section, runtime behavior is byte-for-byte unchanged (verified end-to-end in the final review).

Design: `docs/superpowers/specs/2026-07-20-ble-gatt-proxy-design.md` · Plan: `docs/superpowers/plans/2026-07-20-ble-gatt-proxy.md`

## Approach

- **Single radio** (Approach A) — the Pi's onboard controller does concurrent central+peripheral (BlueZ reports both roles). Dual-adapter is the documented fallback.
- **No MAC-cloning** — the app selects by name from a scan list; while we hold the VVM's slot the real VVM isn't advertising, so the app only ever sees our peripheral.
- **Open GATT** — the VVM link has no pairing/bonding/encryption, so there's no security handshake to replicate.
- New dependency: `bless==0.3.0` (BLE peripheral over BlueZ) alongside `bleak`.

## Status — DRAFT, blocked on hardware validation

All **host-testable** work is complete and reviewed (per-task spec+quality reviews, a final whole-branch review on the most capable model, and a fix wave for its two findings). **196 tests green.**

Remaining before this is mergeable (needs the boat with the engine **powered on** — the VVM is currently off):

- [ ] **Task 0 — concurrency spike** (`tools/proxy_concurrency_spike.py`): prove the onboard radio sustains central+peripheral *while the VVM link is held*. This is the true single-radio go/no-go; if it fails, pivot to the dual-adapter fallback.
- [ ] **Task 8 — end-to-end on the boat**: deploy this branch's `pr-` image, enable `proxy:`, confirm the native app connects through the proxy AND SignalK keeps flowing AND the capture file populates; then check the forwarded indicate-subscribes (`0x301/0x302/0x401/0x2a05`) don't drop the upstream link (the open #37 question — capture log settles it).

Known deferred follow-ups (non-blocking, tracked in the design): sequential connect-time pre-reads could be parallelized; a few off-loop/defensive branches are covered only on hardware; harden write-arbitration once the capture shows real app behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
